### PR TITLE
Add domain-specific rules and selector

### DIFF
--- a/compliance_guardian/agents/rule_selector.py
+++ b/compliance_guardian/agents/rule_selector.py
@@ -1,0 +1,232 @@
+"""Utility to load and manage domain-specific compliance rules."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+import typer
+
+from compliance_guardian.utils.models import Rule, ComplianceDomain
+
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class RuleLoadError(Exception):
+    """Custom error raised when rule loading fails."""
+
+
+class _RuleFileHandler(FileSystemEventHandler):
+    """Internal handler to reload rules on file modification."""
+
+    def __init__(self, selector: "RuleSelector") -> None:
+        self.selector = selector
+        super().__init__()
+
+    def on_modified(self, event) -> None:  # pragma: no cover
+        """Handle file modification events."""
+        path = Path(event.src_path)
+        if path.suffix == ".json" and path.parent == self.selector.rules_dir:
+            domain = path.stem
+            LOGGER.info("Detected change in %s; reloading rules", path)
+            try:
+                self.selector.reload(domain)
+            except Exception as exc:  # pragma: no cover - log unexpected
+                LOGGER.error("Failed to reload %s: %s", domain, exc)
+
+
+class RuleSelector:
+    """Loader and cache for compliance rule sets.
+
+    This class loads rules from ``config/rules/{domain}.json`` and keeps an in
+    memory cache. Files are watched using ``watchdog`` and are hot reloaded
+    when changed.
+    """
+
+    def __init__(self, rules_dir: Optional[Path] = None) -> None:
+        default_dir = Path(__file__).resolve().parents[1] / "config" / "rules"
+        self.rules_dir = rules_dir or default_dir
+        self._cache: Dict[str, List[Rule]] = {}
+        self._observer: Optional[Observer] = None
+        self._start_watcher()
+
+    # ------------------------------------------------------------
+    def _start_watcher(self) -> None:
+        """Start watchdog observer to auto reload rules."""
+        if self._observer:
+            return
+        handler = _RuleFileHandler(self)
+        self._observer = Observer()
+        self._observer.schedule(
+            handler,
+            str(self.rules_dir),
+            recursive=False,
+        )
+        self._observer.start()
+        LOGGER.info("Started watchdog observer on %s", self.rules_dir)
+
+    # ------------------------------------------------------------
+    def _strip_comments(self, data: str) -> str:
+        """Remove comment lines starting with '#', '//' or C-style blocks."""
+        lines = []
+        in_block = False
+        for line in data.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("/*"):
+                in_block = True
+                continue
+            if in_block:
+                if stripped.endswith("*/"):
+                    in_block = False
+                continue
+            if stripped.startswith("//") or stripped.startswith("#"):
+                continue
+            lines.append(line)
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------
+    def _load_file(self, domain: str) -> List[Rule]:
+        """Load rules for ``domain`` from JSON file.
+
+        Args:
+            domain: Domain name matching a file in the rules directory.
+
+        Returns:
+            List of valid :class:`Rule` objects.
+
+        Raises:
+            RuleLoadError: If the file cannot be parsed.
+        """
+        path = self.rules_dir / f"{domain}.json"
+        if not path.exists():
+            raise RuleLoadError(f"Rule file not found: {path}")
+
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(self._strip_comments(raw))
+        except Exception as exc:
+            raise RuleLoadError(f"Failed to parse {path}: {exc}") from exc
+
+        if not isinstance(data, list):
+            raise RuleLoadError(f"Rule file {path} must contain a JSON list")
+
+        rules: List[Rule] = []
+        for idx, entry in enumerate(data):
+            if not isinstance(entry, dict):
+                LOGGER.error(
+                    "Invalid rule entry at index %s: not an object",
+                    idx,
+                )
+                continue
+            if "domain" not in entry:
+                entry["domain"] = ComplianceDomain.OTHER
+            try:
+                rule = Rule.from_dict(entry)
+                rules.append(rule)
+            except ValueError as exc:
+                LOGGER.error(
+                    "Skipping rule %s due to validation error: %s",
+                    idx,
+                    exc,
+                )
+        LOGGER.info("Loaded %d rules for domain %s", len(rules), domain)
+        return rules
+
+    # ------------------------------------------------------------
+    def load(self, domain: str) -> List[Rule]:
+        """Return rules for a domain, loading them if necessary."""
+        if domain not in self._cache:
+            self._cache[domain] = self._load_file(domain)
+        return self._cache[domain]
+
+    # ------------------------------------------------------------
+    def reload(self, domain: str) -> None:
+        """Force reload of rules for a domain."""
+        self._cache[domain] = self._load_file(domain)
+        LOGGER.info("Reloaded rules for domain %s", domain)
+
+    # ------------------------------------------------------------
+    def search(self, domain: str, term: str) -> List[Rule]:
+        """Search loaded rules containing ``term`` in description."""
+        pattern = re.compile(re.escape(term), re.IGNORECASE)
+        results: List[Rule] = []
+        for rule in self.load(domain):
+            if pattern.search(rule.description):
+                results.append(rule)
+
+        LOGGER.info(
+            "Found %d rules matching '%s' in domain %s",
+            len(results),
+            term,
+            domain,
+        )
+        return results
+
+    # ------------------------------------------------------------
+    def validate(self, domain: str) -> List[str]:
+        """Validate rules for a domain and return error messages."""
+        path = self.rules_dir / f"{domain}.json"
+        errors: List[str] = []
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(self._strip_comments(raw))
+        except Exception as exc:
+            errors.append(f"Failed to parse {path}: {exc}")
+            return errors
+        if not isinstance(data, list):
+            errors.append(f"File {path} must contain a JSON list")
+            return errors
+        for idx, entry in enumerate(data):
+            if not isinstance(entry, dict):
+                errors.append(f"Entry {idx} is not an object")
+                continue
+            if "domain" not in entry:
+                entry["domain"] = ComplianceDomain.OTHER
+            try:
+                Rule.from_dict(entry)
+            except ValueError as exc:
+                errors.append(f"Entry {idx} validation error: {exc}")
+        return errors
+
+
+app = typer.Typer(help="CLI for inspecting compliance rules")
+selector = RuleSelector()
+
+
+@app.command()
+def print_rules(domain: str) -> None:
+    """Print all rules for a domain."""
+    for rule in selector.load(domain):
+        typer.echo(rule.json())
+
+
+@app.command()
+def search(domain: str, term: str) -> None:
+    """Search rule descriptions for a term."""
+    for rule in selector.search(domain, term):
+        typer.echo(rule.json())
+
+
+@app.command()
+def validate(domain: str) -> None:
+    """Validate rule file and display any errors."""
+    errors = selector.validate(domain)
+    if errors:
+        for err in errors:
+            typer.echo(f"Error: {err}")
+        raise typer.Exit(code=1)
+    typer.echo("All rules valid")
+
+
+if __name__ == "__main__":
+    for d in ("scraping", "finance", "medical"):
+        print(f"\nDomain: {d}")
+        for r in selector.load(d):
+            print(r.json())

--- a/compliance_guardian/config/rules/finance.json
+++ b/compliance_guardian/config/rules/finance.json
@@ -1,0 +1,64 @@
+# Finance domain: aligned with financial regulations. A "BLOCK" action
+# prevents execution of the financial transaction or disclosure.
+[
+  {
+    "rule_id": "FIN001",
+    "description": "Do not expose full account or credit card numbers.",
+    "type": "regex",
+    "severity": "high",
+    "pattern": "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b",
+    "keywords": [],
+    "llm_instruction": null,
+    "clause_mapping": {"PCI DSS": "Req. 3"},
+    "legal_reference": "https://www.pcisecuritystandards.org/",
+    "example_violation": "Customer card 1234-5678-9012-3456"
+  },
+  {
+    "rule_id": "FIN002",
+    "description": "Avoid misleading guarantees of investment returns.",
+    "type": "semantic",
+    "severity": "medium",
+    "pattern": null,
+    "keywords": ["guaranteed", "risk-free", "no loss"],
+    "llm_instruction": null,
+    "clause_mapping": {"SEC": "Rule 10b-5"},
+    "legal_reference": "https://www.sec.gov/rules/final/33-7825.htm",
+    "example_violation": "Our fund offers guaranteed 20% returns"
+  },
+  {
+    "rule_id": "FIN003",
+    "description": "Require customer consent before sharing financial data with third parties.",
+    "type": "llm",
+    "severity": "high",
+    "pattern": null,
+    "keywords": [],
+    "llm_instruction": "Verify documented consent before any data sharing; otherwise BLOCK the request.",
+    "clause_mapping": {"GDPR Art. 6": "Lawfulness of processing"},
+    "legal_reference": "https://gdpr-info.eu/art-6-gdpr/",
+    "example_violation": "Sending transaction history to marketing partner"
+  },
+  {
+    "rule_id": "FIN004",
+    "description": "Detect text suggesting discriminatory lending or denial based on protected attributes.",
+    "type": "semantic",
+    "severity": "high",
+    "pattern": null,
+    "keywords": ["redline", "minority", "race", "gender"],
+    "llm_instruction": null,
+    "clause_mapping": {"Equal Credit Opportunity": "15 U.S.C. §1691"},
+    "legal_reference": "https://www.consumerfinance.gov/rules-policy/regulations/1002/",
+    "example_violation": "We avoid loans in minority neighborhoods"
+  },
+  {
+    "rule_id": "FIN005",
+    "description": "Prevent insider trading tips or non-public information disclosures.",
+    "type": "llm",
+    "severity": "high",
+    "pattern": null,
+    "keywords": [],
+    "llm_instruction": "If text contains non-public financial details intended for trading advantage, BLOCK and log.",
+    "clause_mapping": {"US Securities": "15 U.S.C. §78j"},
+    "legal_reference": "https://www.law.cornell.edu/uscode/text/15/78j",
+    "example_violation": "Buy shares before earnings announcement tomorrow"
+  }
+]

--- a/compliance_guardian/config/rules/medical.json
+++ b/compliance_guardian/config/rules/medical.json
@@ -1,0 +1,64 @@
+# Medical domain: reflects HIPAA and medical ethics. A "BLOCK" action
+# halts disclosure or generation of sensitive health information.
+[
+  {
+    "rule_id": "MED001",
+    "description": "Mask patient identifiers such as patient IDs or SSNs.",
+    "type": "regex",
+    "severity": "high",
+    "pattern": "(?i)(patient\\s*id[:=]\\s*\\d+|\\b\\d{3}-\\d{2}-\\d{4}\\b)",
+    "keywords": [],
+    "llm_instruction": null,
+    "clause_mapping": {"HIPAA": "45 CFR §164.502"},
+    "legal_reference": "https://www.hhs.gov/hipaa/for-professionals/privacy/index.html",
+    "example_violation": "Patient ID=12345 admitted yesterday"
+  },
+  {
+    "rule_id": "MED002",
+    "description": "Flag unsubstantiated miracle cure claims.",
+    "type": "semantic",
+    "severity": "medium",
+    "pattern": null,
+    "keywords": ["miracle cure", "100% effective", "guaranteed healing"],
+    "llm_instruction": null,
+    "clause_mapping": {"FDA": "21 CFR §202"},
+    "legal_reference": "https://www.ecfr.gov/current/title-21/chapter-I/subchapter-B/part-202",
+    "example_violation": "This herbal pill is a 100% effective cancer cure"
+  },
+  {
+    "rule_id": "MED003",
+    "description": "Require informed consent before using patient data for research.",
+    "type": "llm",
+    "severity": "high",
+    "pattern": null,
+    "keywords": [],
+    "llm_instruction": "Check for documented patient consent before research use; without it issue a BLOCK.",
+    "clause_mapping": {"Declaration of Helsinki": "Paragraph 25"},
+    "legal_reference": "https://www.wma.net/what-we-do/medical-ethics/declaration-of-helsinki/",
+    "example_violation": "Publishing case study without consent"
+  },
+  {
+    "rule_id": "MED004",
+    "description": "Detect biased or discriminatory language in clinical notes.",
+    "type": "llm",
+    "severity": "high",
+    "pattern": null,
+    "keywords": [],
+    "llm_instruction": "Flag and BLOCK notes that stereotype patients based on race, gender, or disability.",
+    "clause_mapping": {"AMA Ethics": "Opinion 1.1"},
+    "legal_reference": "https://code-medical-ethics.ama-assn.org/ethics-opinions",
+    "example_violation": "The patient is non-compliant because of her ethnicity"
+  },
+  {
+    "rule_id": "MED005",
+    "description": "Avoid copying entire copyrighted medical articles.",
+    "type": "regex",
+    "severity": "high",
+    "pattern": "(?i)(©|\\ball rights reserved\\b)\\s.*medical",
+    "keywords": [],
+    "llm_instruction": null,
+    "clause_mapping": {"Copyright": "17 U.S.C."},
+    "legal_reference": "https://www.copyright.gov/title17/",
+    "example_violation": "© 2024 Medical Journal of Examples all rights reserved"
+  }
+]

--- a/compliance_guardian/config/rules/scraping.json
+++ b/compliance_guardian/config/rules/scraping.json
@@ -1,0 +1,64 @@
+# Scraping domain: compliance with privacy and copyright laws. A "BLOCK" action
+# stops scraping activity and prevents using or storing scraped data.
+[
+  {
+    "rule_id": "SCR001",
+    "description": "Block collection of email addresses or phone numbers without user consent.",
+    "type": "regex",
+    "severity": "high",
+    "pattern": "(?i)([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})|((?:\\+?\\d{1,3})?\\s?(?:\\(\\d{1,4}\\)|\\d{1,4})?[\\s-]?\\d{3}[\\s-]?\\d{4})",
+    "keywords": [],
+    "llm_instruction": null,
+    "clause_mapping": {"GDPR Art. 6": "Lawfulness of processing"},
+    "legal_reference": "https://gdpr-info.eu/art-6-gdpr/",
+    "example_violation": "Contact us at example@example.com for more info"
+  },
+  {
+    "rule_id": "SCR002",
+    "description": "Respect robots.txt and meta tags prohibiting scraping.",
+    "type": "semantic",
+    "severity": "medium",
+    "pattern": null,
+    "keywords": ["robots", "disallow", "noindex", "nofollow"],
+    "llm_instruction": null,
+    "clause_mapping": {"EU ePrivacy": "Directive 2002/58/EC"},
+    "legal_reference": "https://eur-lex.europa.eu/eli/dir/2002/58/oj",
+    "example_violation": "Robots.txt contains 'Disallow: /private' but scraper ignores it"
+  },
+  {
+    "rule_id": "SCR003",
+    "description": "Ensure explicit consent before scraping social media profiles.",
+    "type": "llm",
+    "severity": "high",
+    "pattern": null,
+    "keywords": [],
+    "llm_instruction": "If user consent is missing, do not scrape social network data and report a BLOCK.",
+    "clause_mapping": {"GDPR Art. 7": "Conditions for consent"},
+    "legal_reference": "https://gdpr-info.eu/art-7-gdpr/",
+    "example_violation": "Scraping friends list without consent"
+  },
+  {
+    "rule_id": "SCR004",
+    "description": "Avoid scraping text marked with copyright notices or 'all rights reserved'.",
+    "type": "regex",
+    "severity": "high",
+    "pattern": "(?i)(©|\\ball rights reserved\\b)",
+    "keywords": [],
+    "llm_instruction": null,
+    "clause_mapping": {"EU Copyright": "Directive 2001/29/EC"},
+    "legal_reference": "https://eur-lex.europa.eu/eli/dir/2001/29/oj",
+    "example_violation": "Downloading article with © 2024 Example Corp"
+  },
+  {
+    "rule_id": "SCR005",
+    "description": "Do not circumvent paywalls or authentication mechanisms while scraping.",
+    "type": "semantic",
+    "severity": "high",
+    "pattern": null,
+    "keywords": ["paywall", "bypass", "circumvent"],
+    "llm_instruction": null,
+    "clause_mapping": {"Computer Misuse": "18 U.S.C. § 1030"},
+    "legal_reference": "https://www.law.cornell.edu/uscode/text/18/1030",
+    "example_violation": "Using scripts to access premium articles without paying"
+  }
+]


### PR DESCRIPTION
## Summary
- add comprehensive rule sets for scraping, finance, and medical domains
- implement new `rule_selector` with hot reload, caching, and CLI

## Testing
- `flake8 compliance_guardian/agents/rule_selector.py`
- `mypy compliance_guardian/agents/rule_selector.py --ignore-missing-imports`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688659454e9c832ab3579f1ee6931062