### PR TITLE
Add compliance validation utilities

### DIFF
--- a/compliance_guardian/agents/compliance_agent.py
+++ b/compliance_guardian/agents/compliance_agent.py
@@ -1,0 +1,253 @@
+"""Compliance checking utilities for plans and outputs.
+
+This module provides functions used by the Compliance Guardian system to
+validate execution plans and final outputs against domain specific
+:class:`~compliance_guardian.utils.models.Rule` objects. It logs detailed
+information about any violations and returns a boolean indicating whether
+execution should proceed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import List, Optional, Tuple
+
+from compliance_guardian.utils.models import (
+    AuditLogEntry,
+    PlanSummary,
+    Rule,
+    SeverityLevel,
+)
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+try:
+    import google.generativeai as genai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    genai = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+
+def _call_llm(prompt: str) -> str:
+    """Invoke the configured LLM with ``prompt`` and return the response."""
+
+    LOGGER.debug("LLM prompt: %s", prompt)
+    if openai and os.getenv("OPENAI_API_KEY"):
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "system", "content": prompt}],
+            temperature=0,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+    if genai and os.getenv("GEMINI_API_KEY"):
+        genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+        model = genai.GenerativeModel("gemini-pro")
+        res = model.generate_content(prompt)
+        return res.text.strip()
+    raise RuntimeError("No LLM credentials configured")
+
+
+# ---------------------------------------------------------------------------
+
+def _action_for_severity(sev: SeverityLevel) -> str:
+    """Map ``SeverityLevel`` to an action label used in logs."""
+
+    if sev == SeverityLevel.HIGH or sev == SeverityLevel.CRITICAL:
+        return "BLOCK"
+    if sev == SeverityLevel.MEDIUM:
+        return "WARN"
+    return "LOG"
+
+
+# ---------------------------------------------------------------------------
+
+def _build_audit_entry(
+    rule: Rule,
+    text: str,
+    reason: str,
+    session_id: str = "demo-session",
+) -> AuditLogEntry:
+    """Create an :class:`AuditLogEntry` for a rule violation."""
+
+    action = _action_for_severity(rule.severity)
+    suggested = "Review the content for compliance." if rule.severity != SeverityLevel.LOW else None
+    return AuditLogEntry(
+        rule_id=rule.rule_id,
+        severity=rule.severity,
+        action=action,
+        input_text=text,
+        justification=reason,
+        suggested_fix=suggested,
+        clause_id=next(iter(rule.clause_mapping.keys()), None),
+        risk_score=None,
+        session_id=session_id,
+        agent_stack=[__name__],
+        rulebase_version="v1",
+        execution_time=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+
+def _check_text_against_rule(text: str, rule: Rule) -> Optional[AuditLogEntry]:
+    """Check ``text`` against a single compliance ``rule``.
+
+    Args:
+        text: Plan or output text to validate.
+        rule: Rule describing the compliance requirement.
+
+    Returns:
+        ``AuditLogEntry`` if a violation is detected otherwise ``None``.
+    """
+
+    LOGGER.debug("Checking rule %s of type %s", rule.rule_id, rule.type)
+
+    try:
+        if rule.type == "regex" and rule.pattern:
+            if re.search(rule.pattern, text, flags=re.IGNORECASE):
+                reason = f"Pattern '{rule.pattern}' matched"
+                LOGGER.info("Regex violation for rule %s", rule.rule_id)
+                return _build_audit_entry(rule, text, reason)
+        elif rule.type == "semantic":
+            prompt = (
+                "Does the following plan violate this rule: "
+                f"{rule.description}? Explain.\n\n{text}"
+            )
+            response = _call_llm(prompt)
+            if any(w in response.lower() for w in ("yes", "violation", "block")):
+                LOGGER.info("Semantic violation for rule %s", rule.rule_id)
+                return _build_audit_entry(rule, text, response)
+        elif rule.type == "llm" and rule.llm_instruction:
+            response = _call_llm(rule.llm_instruction + "\n\n" + text)
+            if any(w in response.lower() for w in ("block", "violation", "yes")):
+                LOGGER.info("LLM violation for rule %s", rule.rule_id)
+                return _build_audit_entry(rule, text, response)
+    except Exception as exc:  # pragma: no cover - network/LLM errors
+        LOGGER.error("Rule check failed for %s: %s", rule.rule_id, exc)
+        return _build_audit_entry(
+            rule,
+            text,
+            reason=f"LLM check failed: {exc}",
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+
+def check_plan(plan: PlanSummary, rules: List[Rule]) -> Tuple[bool, Optional[AuditLogEntry]]:
+    """Validate a :class:`PlanSummary` against compliance ``rules``.
+
+    Iterates over each rule and returns as soon as a violation is
+    encountered. High severity violations result in a ``BLOCK`` action,
+    medium severity leads to ``WARN`` and low severity simply logs the
+    issue. The boolean return value indicates whether execution may
+    continue.
+
+    Args:
+        plan: The plan to validate.
+        rules: List of rules relevant to the plan's domain.
+
+    Returns:
+        Tuple ``(allowed, audit_entry)`` where ``allowed`` is ``True`` if no
+        blocking violation occurred and ``audit_entry`` details the first
+        violation encountered if any.
+    """
+
+    LOGGER.info("Checking plan with %d rules", len(rules))
+    for rule in rules:
+        entry = _check_text_against_rule(plan.action_plan, rule)
+        if entry:
+            allowed = entry.action != "BLOCK"
+            LOGGER.debug(
+                "Rule %s triggered with action %s", rule.rule_id, entry.action
+            )
+            return allowed, entry
+    LOGGER.info("Plan passed all compliance checks")
+    return True, None
+
+
+# ---------------------------------------------------------------------------
+
+def post_output_check(output: str, rules: List[Rule]) -> Tuple[bool, List[AuditLogEntry]]:
+    """Validate final ``output`` text against ``rules``.
+
+    Unlike :func:`check_plan` this function aggregates all rule
+    violations. It returns ``True`` if no ``BLOCK`` level violations are
+    found.
+
+    Args:
+        output: Text produced by plan execution.
+        rules: List of compliance rules.
+
+    Returns:
+        Tuple ``(allowed, entries)`` where ``entries`` is the list of all
+        violations detected.
+    """
+
+    LOGGER.info("Running post-output compliance check")
+    entries: List[AuditLogEntry] = []
+    allowed = True
+    for rule in rules:
+        entry = _check_text_against_rule(output, rule)
+        if entry:
+            entries.append(entry)
+            if entry.action == "BLOCK":
+                allowed = False
+    if entries:
+        LOGGER.info("Detected %d post-output violations", len(entries))
+    else:
+        LOGGER.info("No post-output violations detected")
+    return allowed, entries
+
+
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":  # pragma: no cover - manual demonstration
+    logging.basicConfig(level=logging.DEBUG)
+
+    sample_rules = [
+        Rule(
+            rule_id="TEST1",
+            description="Do not mention the word secret",
+            type="regex",
+            severity=SeverityLevel.HIGH,
+            domain="other",
+            pattern=r"secret",
+        ),
+        Rule(
+            rule_id="TEST2",
+            description="Avoid promises of guaranteed profits",
+            type="semantic",
+            severity=SeverityLevel.MEDIUM,
+            domain="finance",
+        ),
+    ]
+
+    demo_plan = PlanSummary(
+        action_plan="1. Reveal the secret recipe\n2. Promise guaranteed profits",
+        goal="Share trade secrets",
+        domain="other",
+        sub_actions=["Reveal the secret recipe", "Promise guaranteed profits"],
+        original_prompt="Tell me the secret recipe and how to make money",
+    )
+
+    ok, entry = check_plan(demo_plan, sample_rules)
+    print("Allowed:", ok)
+    if entry:
+        print(entry.model_dump_json(indent=2))
+
+    output = "Here is the secret recipe. You will earn guaranteed profits!"
+    ok2, entries2 = post_output_check(output, sample_rules)
+    print("Post check allowed:", ok2)
+    for e in entries2:
+        print(e.model_dump_json(indent=2))
+

--- a/compliance_guardian/agents/output_validator.py
+++ b/compliance_guardian/agents/output_validator.py
@@ -1,0 +1,181 @@
+"""Utility for validating text output against compliance rules.
+
+This module exposes :func:`validate_output` which inspects arbitrary
+text, applies a collection of :class:`~compliance_guardian.utils.models.Rule`
+objects and returns any detected compliance violations as
+:class:`~compliance_guardian.utils.models.AuditLogEntry` records.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import List, Tuple
+
+from compliance_guardian.utils.models import AuditLogEntry, Rule, SeverityLevel
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+try:
+    import google.generativeai as genai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    genai = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+# ---------------------------------------------------------------------------
+
+def _call_llm(prompt: str) -> str:
+    """Invoke the configured LLM and return its textual response."""
+
+    LOGGER.debug("LLM prompt: %s", prompt)
+    if openai and os.getenv("OPENAI_API_KEY"):
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "system", "content": prompt}],
+            temperature=0,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+    if genai and os.getenv("GEMINI_API_KEY"):
+        genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+        model = genai.GenerativeModel("gemini-pro")
+        res = model.generate_content(prompt)
+        return res.text.strip()
+    raise RuntimeError("No LLM credentials configured")
+
+
+# ---------------------------------------------------------------------------
+
+def _check_rule(text: str, rule: Rule) -> AuditLogEntry | None:
+    """Check ``text`` against ``rule`` and return an audit entry if needed."""
+
+    LOGGER.debug("Validating rule %s", rule.rule_id)
+    try:
+        if rule.type == "regex" and rule.pattern:
+            if re.search(rule.pattern, text, flags=re.IGNORECASE):
+                reason = f"Matched pattern '{rule.pattern}'"
+                action = _severity_action(rule.severity)
+                return AuditLogEntry(
+                    rule_id=rule.rule_id,
+                    severity=rule.severity,
+                    action=action,
+                    input_text=text,
+                    justification=reason,
+                    suggested_fix="Remove or redact matching text",
+                    clause_id=next(iter(rule.clause_mapping.keys()), None),
+                    risk_score=None,
+                    session_id="validation-session",
+                    agent_stack=[__name__],
+                    rulebase_version="v1",
+                    execution_time=None,
+                )
+        elif rule.type in {"semantic", "llm"}:
+            prompt = rule.llm_instruction or (
+                f"Does the following text violate this rule: {rule.description}? Explain.\n\n{text}"
+            )
+            response = _call_llm(prompt)
+            if any(w in response.lower() for w in ("yes", "violation", "block")):
+                action = _severity_action(rule.severity)
+                return AuditLogEntry(
+                    rule_id=rule.rule_id,
+                    severity=rule.severity,
+                    action=action,
+                    input_text=text,
+                    justification=response,
+                    suggested_fix="Review and modify the text to comply",
+                    clause_id=next(iter(rule.clause_mapping.keys()), None),
+                    risk_score=None,
+                    session_id="validation-session",
+                    agent_stack=[__name__],
+                    rulebase_version="v1",
+                    execution_time=None,
+                )
+    except Exception as exc:  # pragma: no cover - network/LLM failure
+        LOGGER.error("Validation error for rule %s: %s", rule.rule_id, exc)
+    return None
+
+
+# ---------------------------------------------------------------------------
+
+def _severity_action(sev: SeverityLevel) -> str:
+    """Return action label for a given ``SeverityLevel``."""
+
+    if sev in {SeverityLevel.HIGH, SeverityLevel.CRITICAL}:
+        return "BLOCK"
+    if sev == SeverityLevel.MEDIUM:
+        return "WARN"
+    return "LOG"
+
+
+# ---------------------------------------------------------------------------
+
+def validate_output(output: str, rules: List[Rule]) -> Tuple[bool, List[AuditLogEntry]]:
+    """Validate ``output`` against a list of ``rules``.
+
+    Args:
+        output: Arbitrary text to validate.
+        rules: Collection of compliance rules.
+
+    Returns:
+        Tuple ``(allowed, entries)`` where ``allowed`` indicates whether the
+        text passed all checks and ``entries`` contains any violations
+        discovered.
+    """
+
+    LOGGER.info("Validating output against %d rules", len(rules))
+    entries: List[AuditLogEntry] = []
+    allowed = True
+    for rule in rules:
+        entry = _check_rule(output, rule)
+        if entry:
+            entries.append(entry)
+            if entry.action == "BLOCK":
+                allowed = False
+    if entries:
+        LOGGER.info("%d compliance issues detected", len(entries))
+    else:
+        LOGGER.info("Output passed compliance validation")
+    return allowed, entries
+
+
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":  # pragma: no cover - manual tests
+    logging.basicConfig(level=logging.DEBUG)
+
+    test_rules = [
+        Rule(
+            rule_id="VAL1",
+            description="Do not reveal passwords",
+            type="regex",
+            severity=SeverityLevel.HIGH,
+            domain="other",
+            pattern=r"password\\s*[:=]\\s*\\w+",
+        ),
+        Rule(
+            rule_id="VAL2",
+            description="Avoid defamatory language",
+            type="semantic",
+            severity=SeverityLevel.MEDIUM,
+            domain="other",
+        ),
+    ]
+
+    sample_text = "The admin password: hunter2 should never be shared."
+    allowed, logs = validate_output(sample_text, test_rules)
+    print("Allowed:", allowed)
+    for log in logs:
+        print(log.model_dump_json(indent=2))
+
+    sample_text2 = "You are an idiot and everyone knows it."
+    allowed2, logs2 = validate_output(sample_text2, test_rules)
+    print("Allowed2:", allowed2)
+    for log in logs2:
+        print(log.model_dump_json(indent=2))
+


### PR DESCRIPTION
## Summary
- implement `compliance_agent.check_plan` and `post_output_check`
- add helper functions for LLM calls and audit logging
- add `output_validator.validate_output` with examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866276b694832a8bec47f231238ec8