### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      # Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up Python 3.12 and enable pip caching
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      # Install project dependencies
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install coverage-badge
+
+      # Run Black and Flake8 for code style and linting
+      - name: Run Black
+        run: black --check .
+      - name: Run Flake8
+        run: flake8
+
+      # Type checking with mypy
+      - name: Run mypy
+        run: mypy .
+
+      # Run unit tests with coverage
+      - name: Run tests
+        run: |
+          pytest --cov=./ --cov-report=xml
+          coverage-badge -o coverage.svg -f
+
+      # Build Sphinx documentation (warnings treated as errors)
+      - name: Build docs
+        run: sphinx-build -b html docs docs/_build -W
+
+      # Upload coverage and documentation artifacts
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            coverage.xml
+            coverage.svg
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build
+
+      # Commit coverage badge to README if on push
+      - name: Update coverage badge in README
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if grep -q "coverage.svg" README.md; then
+            echo "README already references coverage.svg"
+          else
+            sed -i "0,/coverage-[0-9]*%/s//coverage.svg/" README.md
+          fi
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md coverage.svg || true
+          git commit -m "chore: update coverage badge" || echo "No changes"
+          git push || echo "Unable to push coverage badge"
+
+      # Print message if any step fails
+      - name: Failure notice
+        if: failure()
+        run: echo "One or more steps failed. Check the logs above for details."


### PR DESCRIPTION
## Summary
- add a CI workflow running lint, type checks, tests, and docs build

## Testing
- `python -m pip install -r requirements.txt`
- `black --check .` *(fails: would reformat files)*
- `python -m flake8` *(fails with E501 line too long)*
- `python -m mypy compliance_guardian` *(fails: several errors)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688685554300832ab9299fdecdc20247