### PR TITLE
Add versioning for rules and agents

### DIFF
--- a/compliance_guardian/agents/domain_classifier.py
+++ b/compliance_guardian/agents/domain_classifier.py
@@ -9,6 +9,11 @@ final classification result.
 
 from __future__ import annotations
 
+# Version of this agent module. Including explicit versions in logs
+# ensures audit trails can be recreated with the exact implementation
+# used when a decision was made.
+__version__ = "0.2.1"
+
 import json
 import logging
 import os

--- a/compliance_guardian/agents/primary_agent.py
+++ b/compliance_guardian/agents/primary_agent.py
@@ -10,6 +10,7 @@ JSON object containing the overall ``goal`` and a list of ``steps``.
 If the LLM cannot be reached the function falls back to a simple,
 heuristic plan.
 
+
 ``execute_task`` -- Executes an approved plan under a set of compliance
 ``Rule`` objects. The rules are injected into the system prompt so the
 LLM understands the operational constraints. If ``approved`` is ``False``
@@ -17,6 +18,8 @@ the function logs the event and aborts gracefully.
 """
 
 from __future__ import annotations
+__version__ = "0.2.1"
+
 
 import json
 import logging

--- a/compliance_guardian/config/rules/finance.json
+++ b/compliance_guardian/config/rules/finance.json
@@ -1,8 +1,9 @@
 # Finance domain: aligned with financial regulations. A "BLOCK" action
 # prevents execution of the financial transaction or disclosure.
-[
+{"version": "1.0.0", "rules": [
   {
     "rule_id": "FIN001",
+    "version": "1.0.0",
     "description": "Do not expose full account or credit card numbers.",
     "type": "regex",
     "severity": "high",
@@ -15,6 +16,7 @@
   },
   {
     "rule_id": "FIN002",
+    "version": "1.0.0",
     "description": "Avoid misleading guarantees of investment returns.",
     "type": "semantic",
     "severity": "medium",
@@ -27,6 +29,7 @@
   },
   {
     "rule_id": "FIN003",
+    "version": "1.0.0",
     "description": "Require customer consent before sharing financial data with third parties.",
     "type": "llm",
     "severity": "high",
@@ -39,6 +42,7 @@
   },
   {
     "rule_id": "FIN004",
+    "version": "1.0.0",
     "description": "Detect text suggesting discriminatory lending or denial based on protected attributes.",
     "type": "semantic",
     "severity": "high",
@@ -51,6 +55,7 @@
   },
   {
     "rule_id": "FIN005",
+    "version": "1.0.0",
     "description": "Prevent insider trading tips or non-public information disclosures.",
     "type": "llm",
     "severity": "high",
@@ -61,4 +66,4 @@
     "legal_reference": "https://www.law.cornell.edu/uscode/text/15/78j",
     "example_violation": "Buy shares before earnings announcement tomorrow"
   }
-]
+]}

--- a/compliance_guardian/config/rules/medical.json
+++ b/compliance_guardian/config/rules/medical.json
@@ -1,8 +1,9 @@
 # Medical domain: reflects HIPAA and medical ethics. A "BLOCK" action
 # halts disclosure or generation of sensitive health information.
-[
+{"version": "1.0.0", "rules": [
   {
     "rule_id": "MED001",
+    "version": "1.0.0",
     "description": "Mask patient identifiers such as patient IDs or SSNs.",
     "type": "regex",
     "severity": "high",
@@ -15,6 +16,7 @@
   },
   {
     "rule_id": "MED002",
+    "version": "1.0.0",
     "description": "Flag unsubstantiated miracle cure claims.",
     "type": "semantic",
     "severity": "medium",
@@ -27,6 +29,7 @@
   },
   {
     "rule_id": "MED003",
+    "version": "1.0.0",
     "description": "Require informed consent before using patient data for research.",
     "type": "llm",
     "severity": "high",
@@ -39,6 +42,7 @@
   },
   {
     "rule_id": "MED004",
+    "version": "1.0.0",
     "description": "Detect biased or discriminatory language in clinical notes.",
     "type": "llm",
     "severity": "high",
@@ -51,6 +55,7 @@
   },
   {
     "rule_id": "MED005",
+    "version": "1.0.0",
     "description": "Avoid copying entire copyrighted medical articles.",
     "type": "regex",
     "severity": "high",
@@ -61,4 +66,4 @@
     "legal_reference": "https://www.copyright.gov/title17/",
     "example_violation": "© 2024 Medical Journal of Examples all rights reserved"
   }
-]
+]}

--- a/compliance_guardian/config/rules/scraping.json
+++ b/compliance_guardian/config/rules/scraping.json
@@ -1,8 +1,9 @@
 # Scraping domain: compliance with privacy and copyright laws. A "BLOCK" action
 # stops scraping activity and prevents using or storing scraped data.
-[
+{"version": "1.0.0", "rules": [
   {
     "rule_id": "SCR001",
+    "version": "1.0.0",
     "description": "Block collection of email addresses or phone numbers without user consent.",
     "type": "regex",
     "severity": "high",
@@ -15,6 +16,7 @@
   },
   {
     "rule_id": "SCR002",
+    "version": "1.0.0",
     "description": "Respect robots.txt and meta tags prohibiting scraping.",
     "type": "semantic",
     "severity": "medium",
@@ -27,6 +29,7 @@
   },
   {
     "rule_id": "SCR003",
+    "version": "1.0.0",
     "description": "Ensure explicit consent before scraping social media profiles.",
     "type": "llm",
     "severity": "high",
@@ -39,6 +42,7 @@
   },
   {
     "rule_id": "SCR004",
+    "version": "1.0.0",
     "description": "Avoid scraping text marked with copyright notices or 'all rights reserved'.",
     "type": "regex",
     "severity": "high",
@@ -51,6 +55,7 @@
   },
   {
     "rule_id": "SCR005",
+    "version": "1.0.0",
     "description": "Do not circumvent paywalls or authentication mechanisms while scraping.",
     "type": "semantic",
     "severity": "high",
@@ -61,4 +66,4 @@
     "legal_reference": "https://www.law.cornell.edu/uscode/text/18/1030",
     "example_violation": "Using scripts to access premium articles without paying"
   }
-]
+]}

--- a/compliance_guardian/utils/models.py
+++ b/compliance_guardian/utils/models.py
@@ -4,7 +4,9 @@ This module defines Pydantic models used throughout the Compliance Guardian
 Agent to ensure structured data handling when performing compliance auditing for
 large language model (LLM) pipelines. The models cover rule definitions, audit
 logging, planning summaries, and session context tracking. These structures
-facilitate rigorous reproducibility that aligns with EU regulations.
+facilitate rigorous reproducibility that aligns with EU regulations.  Each
+model carries explicit version information so historical decisions can be
+recreated exactly with the same rule and agent versions.
 
 Example:
     >>> from compliance_guardian.utils.models import Rule, RuleType, SeverityLevel, ComplianceDomain
@@ -74,6 +76,10 @@ class Rule(BaseModel):
     """
 
     rule_id: str = Field(..., description="Unique identifier for this rule.")
+    version: str = Field(
+        "1.0.0",
+        description="Version identifier for this rule allowing full traceability",
+    )
     description: str = Field(..., description="Human-readable rule description.")
     type: RuleType = Field(..., description="Category of the rule.")
     severity: SeverityLevel = Field(..., description="Impact severity if violated.")
@@ -143,6 +149,8 @@ class AuditLogEntry(BaseModel):
         risk_score: Numerical risk score.
         session_id: Identifier for the session associated.
         agent_stack: List of agents involved.
+        rule_version: Version of the specific rule triggered.
+        agent_versions: Mapping of agent names to their versions.
         rulebase_version: Version of the rulebase in use.
         execution_time: Time taken to execute in seconds.
     """
@@ -163,6 +171,13 @@ class AuditLogEntry(BaseModel):
     session_id: str = Field(..., description="Identifier for the associated session.")
     agent_stack: List[str] = Field(
         default_factory=list, description="List of agents involved."
+    )
+    rule_version: Optional[str] = Field(
+        None, description="Version of the rule that triggered this entry."
+    )
+    agent_versions: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Versions of agents contributing to the decision.",
     )
     rulebase_version: Optional[str] = Field(
         None, description="Version of the rulebase in use."

--- a/tests/test_compliance_agent.py
+++ b/tests/test_compliance_agent.py
@@ -40,7 +40,7 @@ class TestComplianceAgent:
             sub_actions=["bar"],
             original_prompt="p",
         )
-        allowed, entry = compliance_agent.check_plan(plan, [regex_rule])
+        allowed, entry = compliance_agent.check_plan(plan, [regex_rule], "v1")
         assert allowed and entry is None
 
     def test_check_plan_regex_block(self, regex_rule):
@@ -51,7 +51,7 @@ class TestComplianceAgent:
             sub_actions=["foo"],
             original_prompt="p",
         )
-        allowed, entry = compliance_agent.check_plan(plan, [regex_rule])
+        allowed, entry = compliance_agent.check_plan(plan, [regex_rule], "v1")
         assert not allowed
         assert entry and entry.action == "BLOCK"
 
@@ -64,7 +64,7 @@ class TestComplianceAgent:
             original_prompt="p",
         )
         with patch.object(compliance_agent, "_call_llm", return_value="Yes violation"):
-            allowed, entry = compliance_agent.check_plan(plan, [semantic_rule])
+            allowed, entry = compliance_agent.check_plan(plan, [semantic_rule], "v1")
             assert not allowed
             assert entry and "violation" in entry.justification.lower()
 
@@ -79,11 +79,11 @@ class TestComplianceAgent:
         with patch.object(
             compliance_agent, "_call_llm", side_effect=RuntimeError("boom")
         ):
-            allowed, entry = compliance_agent.check_plan(plan, [semantic_rule])
+            allowed, entry = compliance_agent.check_plan(plan, [semantic_rule], "v1")
             assert not allowed
             assert entry and "failed" in entry.justification
 
     def test_post_output_check(self, regex_rule):
-        allowed, entries = compliance_agent.post_output_check("foo bar", [regex_rule])
+        allowed, entries = compliance_agent.post_output_check("foo bar", [regex_rule], "v1")
         assert not allowed
         assert entries and entries[0].rule_id == "R"

--- a/tests/test_output_validator.py
+++ b/tests/test_output_validator.py
@@ -33,13 +33,13 @@ class TestOutputValidator:
         )
 
     def test_regex_rule_detection(self, regex_rule):
-        ok, entries = output_validator.validate_output("this has secret", [regex_rule])
+        ok, entries = output_validator.validate_output("this has secret", [regex_rule], "v1")
         assert not ok and entries
         assert entries[0].action == "BLOCK"
 
     def test_llm_rule(self, llm_rule):
         with patch.object(output_validator, "_call_llm", return_value="Yes violation"):
-            ok, entries = output_validator.validate_output("text", [llm_rule])
+            ok, entries = output_validator.validate_output("text", [llm_rule], "v1")
             assert not ok
             assert entries[0].action == "BLOCK"
 
@@ -49,5 +49,5 @@ class TestOutputValidator:
         assert output_validator._severity_action(models.SeverityLevel.LOW) == "LOG"
 
     def test_validate_output_no_issues(self, regex_rule):
-        ok, entries = output_validator.validate_output("clean", [regex_rule])
+        ok, entries = output_validator.validate_output("clean", [regex_rule], "v1")
         assert ok and not entries


### PR DESCRIPTION
## Summary
- version field added to rule files and model schema
- audit log entries include rule/agent versions
- agent modules expose `__version__`
- update rule selector for file versions
- include version info in reports and tests

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a9c72240832ab2844384995b1fa2