### PR TITLE
Add security and privacy docs

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,60 @@
+# Privacy Overview
+
+This document describes how the **Compliance Guardian Agent**
+collects, stores and deletes data. It is intended for researchers
+and industry practitioners evaluating the system.
+
+## Data Collected
+- **Prompts and plans** submitted by users are logged for audit
+  purposes. These logs include the classified domain, rule IDs,
+  compliance actions and justifications.
+- **Generated outputs** and risk scores are recorded when the
+  compliance agents check the plan or final answer.
+- **User feedback** submitted via the web demo is stored in
+  `reports/user_study.md` along with a timestamp, rating and
+  optional comment.
+
+## Handling Feedback and Pseudonymisation
+- Feedback entries may contain user identifiers or free‑text
+  comments. Before sharing logs externally, replace any personal
+  names or emails with pseudonyms (e.g. `USER_A`).
+- The provided `user_study.record_user_feedback` function can be
+  extended to hash user IDs or drop raw prompts entirely when
+  privacy requirements are strict.
+
+## Retention and Deletion
+- Audit logs under `logs/` are rotated when they reach 5&nbsp;MB. Old
+  log files should be reviewed and deleted after **90&nbsp;days** unless
+  required for ongoing research.
+- Governance reports and user study files in `reports/` should be
+  kept no longer than **six months**.
+- To request deletion of specific logs or feedback entries, contact
+  the project maintainers via `privacy@example.com` with the
+  relevant timestamp or scenario identifier.
+
+## Dataset Provenance
+The project relies on external datasets that are **not** included in
+this repository. See `datasets/README.md` for details, including
+sources and licences:
+- PrivacyQA – CC&nbsp;BY&nbsp;4.0, crowd‑sourced privacy questions【F:datasets/README.md†L8-L16】
+- HH‑RLHF – Apache&nbsp;2.0, helpful/harmless conversations【F:datasets/README.md†L18-L27】
+- OPP‑115 – CC&nbsp;BY‑SA&nbsp;3.0, annotated privacy policies【F:datasets/README.md†L29-L38】
+These datasets are used only for evaluation and rule creation.
+
+## User Rights
+- Participants may opt out of feedback collection at any time by not
+  submitting the form or by requesting deletion of their record.
+- Users may request access to stored logs or reports relating to
+  their prompts by emailing `privacy@example.com`.
+
+## Deployment Limitations
+This project is a research prototype. It does not offer automated
+GDPR compliance guarantees and should not be deployed in production
+without a full privacy impact assessment. LLM outputs may
+inadvertently reveal training data or leak PII.
+
+## Regulatory References
+The system is designed with reference to the EU General Data
+Protection Regulation and ISO/IEC&nbsp;27001 security management
+principles. See the links in `SECURITY.md` for the authoritative
+sources.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Overview
+
+This document outlines the threat model, log handling and other
+security practices for the **Compliance Guardian Agent** project.
+It is written for MSc/industry audiences.
+
+## Threat Model
+- **Data handled**: user prompts, compliance plans, policy rules,
+  audit decisions and generated outputs. The system does not store
+  real personal data outside of demo mode. All processing occurs in
+  memory or temporary files under `logs/` and `reports/`.
+- **Risks**: exposure of sensitive prompts or model outputs,
+  tampering with audit logs, misuse of API credentials or models,
+  and unanticipated LLM behaviours.
+- **Protections**:
+  - Logs are rotated and stored with restricted permissions (see below).
+  - API keys are kept in environment variables and never committed to
+    the repository.
+  - Rule versions and agent versions are embedded in each audit entry
+    to support reproducibility.
+  - Access to the system should be limited to authorised researchers
+    or developers.
+
+## Log File Security
+- Audit logs are appended to `logs/audit_log.jsonl` using the
+  utilities in `compliance_guardian.utils.log_writer`.
+- When the file exceeds 5&nbsp;MB it is renamed to
+  `audit_log_<N>.jsonl` and a fresh log is created.
+- Logs and reports are kept under `logs/` and `reports/` with
+  file permissions restricted to project maintainers.
+- Only maintainers and auditors performing compliance reviews should
+  access these files. Logs may contain prompts or explanations that
+  reveal sensitive business context.
+
+## Handling Personal Data
+- The system is designed to run **without** processing real personal
+  data. Example prompts in the evaluation dataset only contain
+  synthetic or pseudonymous information.
+- In the rare case that a demo requires real data, users must enable
+  a dedicated "demo" flag and ensure all outputs are promptly
+  redacted or pseudonymised before storage.
+- When logs are exported for research, names, emails or account
+  numbers should be replaced with placeholders (e.g. `USER123`).
+
+## Secrets and API Keys
+- OpenAI or Gemini model keys **must** be supplied via environment
+  variables such as `OPENAI_API_KEY` or
+  `GOOGLE_APPLICATION_CREDENTIALS`.
+- Do **not** hard-code credentials or add them to configuration files.
+  Local `.env` files may be used but must never be committed to Git.
+
+## Known Limitations
+- Large language models may still produce inaccurate or unsafe text.
+  Rule coverage is limited to the example domains in
+  `compliance_guardian/config/rules/`.
+- Real-time monitoring of model outputs is best effort and may miss
+  nuanced violations.
+- The project does not implement end‑to‑end encryption for log files;
+  if strict confidentiality is required, store logs on encrypted disk.
+
+## Responsible Disclosure
+If you discover a security vulnerability, please email
+`security@example.com` with:
+
+1. Description of the issue
+2. Steps to reproduce
+3. Potential impact
+
+We will respond within 5 business days and coordinate remediation.
+
+## Further Reading
+- [GDPR text](https://gdpr-info.eu/)
+  – authoritative source on EU data protection requirements.
+- [ISO/IEC&nbsp;27001](https://www.iso.org/standard/54534.html)
+  – international standard for information security management.


### PR DESCRIPTION
## Summary
- document threat model and API key handling in `SECURITY.md`
- document privacy practices and data retention in `PRIVACY.md`

## Testing
- `flake8` *(fails: line length errors)*
- `mypy compliance_guardian` *(fails: several typing errors)*
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886af902db0832a8135787022defba5