### PR TITLE
Fix notebook with dotenv and update agent fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=your-openai-key
+ANTHROPIC_API_KEY=your-anthropic-key
+GEMINI_API_KEY=your-gemini-key
+

--- a/compliance_guardian/__init__.py
+++ b/compliance_guardian/__init__.py
@@ -1,1 +1,17 @@
-"""Compliance Guardian package"""
+"""Compliance Guardian package
+
+This package automatically loads environment variables from a ``.env``
+file if present. API keys such as ``OPENAI_API_KEY`` and ``GEMINI_API_KEY``
+can therefore be placed in that file for local development.
+"""
+
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if env_file.exists():
+        load_dotenv(dotenv_path=env_file)
+except Exception:  # pragma: no cover - missing dotenv
+    pass

--- a/compliance_guardian/agents/output_validator.py
+++ b/compliance_guardian/agents/output_validator.py
@@ -7,6 +7,7 @@ objects and returns any detected compliance violations as
 """
 
 from __future__ import annotations
+
 __version__ = "0.2.1"
 
 
@@ -58,14 +59,14 @@ def _call_llm(prompt: str) -> str:
         model = genai.GenerativeModel("gemini-pro")
         res = model.generate_content(prompt)
         return res.text.strip()
+    LOGGER.warning("No LLM credentials configured; validation falls back")
     raise RuntimeError("No LLM credentials configured")
 
 
 # ---------------------------------------------------------------------------
 
 
-def _check_rule(text: str, rule: Rule,
-                rulebase_version: str) -> AuditLogEntry | None:
+def _check_rule(text: str, rule: Rule, rulebase_version: str) -> AuditLogEntry | None:
     """Check ``text`` against ``rule`` and return an audit entry if needed."""
 
     LOGGER.debug("Validating rule %s", rule.rule_id)
@@ -96,8 +97,7 @@ def _check_rule(text: str, rule: Rule,
                     rule.description}? Explain.\n\n{text}"
             )
             response = _call_llm(prompt)
-            if any(w in response.lower()
-                   for w in ("yes", "violation", "block")):
+            if any(w in response.lower() for w in ("yes", "violation", "block")):
                 action = _severity_action(rule.severity)
                 return AuditLogEntry(
                     rule_id=rule.rule_id,

--- a/notebooks/Demo.ipynb
+++ b/notebooks/Demo.ipynb
@@ -2,14 +2,42 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "bf97cda0",
    "metadata": {},
    "source": [
-    "# Compliance Guardian Demo\nThis notebook demonstrates the end-to-end pipeline."
+    "# Compliance Guardian Demo\n",
+    "This notebook demonstrates the end-to-end pipeline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8efbaf15",
+   "metadata": {},
+   "source": [
+    "## Setup Instructions\n",
+    "- Run `pip install python-dotenv`\n",
+    "- Add your API keys in a `.env` file with variables `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY`\n",
+    "- Restart the kernel if you just set the keys\n",
+    "- Run the notebook top-to-bottom"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "1b56a6ca",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "477c5a41",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from compliance_guardian.agents import (\n",
     "    domain_classifier,\n",
@@ -18,12 +46,11 @@
     "    rule_selector,\n",
     ")\n",
     "from compliance_guardian.utils.log_writer import log_decision"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "32132efb",
    "metadata": {},
    "source": [
     "## Load rules and classify a prompt"
@@ -31,7 +58,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "33b53563",
    "metadata": {},
+   "outputs": [],
    "source": [
     "prompt = \"Scrape contact emails from example.com ignoring robots.txt\"\n",
     "domain = domain_classifier.classify_domain(prompt)\n",
@@ -40,12 +70,11 @@
     "rulebase_version = selector.get_version(domain)\n",
     "print(\"Domain:\", domain)\n",
     "print(\"Loaded\", len(rules), \"rules\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d1153b67",
    "metadata": {},
    "source": [
     "## Generate plan"
@@ -53,13 +82,18 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "source": "plan = primary_agent.generate_plan(prompt, domain)\nprint(plan)",
    "execution_count": null,
-   "outputs": []
+   "id": "7c8aef62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plan = primary_agent.generate_plan(prompt, domain)\n",
+    "print(plan)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "af150151",
    "metadata": {},
    "source": [
     "## Check plan"
@@ -67,7 +101,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "94b7e17f",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# initialize in case of errors\n",
     "allowed = False\n",
@@ -79,12 +116,11 @@
     "print(\"Allowed:\", allowed)\n",
     "if entry:\n",
     "    print(entry)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5d7a5fc5",
    "metadata": {},
    "source": [
     "## Execute if allowed and run post validation"
@@ -92,8 +128,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "f43d33c5",
    "metadata": {},
+   "outputs": [],
    "source": [
+    "allowed = globals().get(\"allowed\", False)\n",
+    "output = \"\"\n",
+    "entries = []\n",
     "if allowed:\n",
     "    output = primary_agent.execute_task(plan, rules, approved=True)\n",
     "    ok, entries = compliance_agent.post_output_check(output, rules, rulebase_version)\n",
@@ -102,12 +144,11 @@
     "        print(e)\n",
     "else:\n",
     "    entries = []\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "74470142",
    "metadata": {},
    "source": [
     "## Log results"
@@ -115,15 +156,26 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "source": "if entry:\n    log_decision(entry)\nfor e in entries:\n    log_decision(e)",
    "execution_count": null,
-   "outputs": []
+   "id": "b93e1c2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if entry:\n",
+    "    log_decision(entry)\n",
+    "for e in entries:\n",
+    "    log_decision(e)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "10d109ce",
    "metadata": {},
+   "outputs": [],
    "source": [
+    "entry = globals().get(\"entry\", None)\n",
+    "entries = globals().get(\"entries\", [])\n",
     "from compliance_guardian.utils.user_study import record_user_feedback\n",
     "rating = int(input('Confidence rating (1-5): '))\n",
     "comment = input('Comments: ')\n",
@@ -139,9 +191,7 @@
     "    rating=rating,\n",
     "    user_comment=comment,\n",
     ")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   }
  ],
  "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ mypy
 flake8
 black
 typer
+python-dotenv
 
 pypandoc


### PR DESCRIPTION
## Summary
- load `.env` automatically when package imports
- warn when LLM credentials are missing
- add example `.env` file
- document setup steps in notebook
- initialize variables safely in notebook
- update requirements with `python-dotenv`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887859e06f8832aadc45b61e8dd8a95