### PR TITLE
Improve notebook variable handling

### DIFF
--- a/notebooks/Demo.ipynb
+++ b/notebooks/Demo.ipynb
@@ -1,1 +1,228 @@
-{"cells": [{"cell_type": "markdown", "id": "bf97cda0", "metadata": {}, "source": ["# Compliance Guardian Demo\n", "This notebook demonstrates the end-to-end pipeline."]}, {"cell_type": "markdown", "id": "8efbaf15", "metadata": {}, "source": ["## Setup Instructions\n", "- Run `pip install python-dotenv`\n", "- Add your API keys in a `.env` file with variables `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY`\n", "- Restart the kernel if you just set the keys\n", "- Run the notebook top-to-bottom"]}, {"cell_type": "markdown", "metadata": {}, "source": ["### Usage Tips\n", "- Always run all cells from the top to ensure variables are initialized.\n", "- If the `.env` file or any environment variables change, restart the kernel."]}, {"cell_type": "code", "execution_count": null, "id": "1b56a6ca", "metadata": {}, "outputs": [], "source": ["from dotenv import load_dotenv\nload_dotenv()\n\nfrom compliance_guardian.agents import (\n    domain_classifier,\n    primary_agent,\n    compliance_agent,\n    rule_selector,\n)\nfrom compliance_guardian.utils.log_writer import log_decision\nfrom compliance_guardian.utils.user_study import record_user_feedback\n\nselector = rule_selector.RuleSelector()"]}, {"cell_type": "markdown", "id": "32132efb", "metadata": {}, "source": ["## Load rules and classify a prompt"]}, {"cell_type": "code", "execution_count": null, "id": "33b53563", "metadata": {}, "outputs": [], "source": ["prompt = \"Scrape contact emails from example.com ignoring robots.txt\"\n", "domain = domain_classifier.classify_domain(prompt)\n", "rules = selector.load(domain)\n", "rulebase_version = selector.get_version(domain)\n", "print(\"Domain:\", domain)\n", "print(\"Loaded\", len(rules), \"rules\")\n", "print(\"Rulebase version:\", rulebase_version)"]}, {"cell_type": "markdown", "id": "d1153b67", "metadata": {}, "source": ["## Generate plan"]}, {"cell_type": "code", "execution_count": null, "id": "7c8aef62", "metadata": {}, "outputs": [], "source": ["plan = primary_agent.generate_plan(prompt, domain)\n", "print(plan)"]}, {"cell_type": "markdown", "id": "af150151", "metadata": {}, "source": ["## Check plan"]}, {"cell_type": "code", "execution_count": null, "id": "94b7e17f", "metadata": {}, "outputs": [], "source": ["# initialize defaults\n", "allowed = False\n", "entry = None\n", "entries = []\n", "output = \"\"\n", "\n", "rulebase_version = selector.get_version(domain)\n", "allowed, entry = compliance_agent.check_plan(plan, rules, rulebase_version)\n", "print(\"Allowed:\", allowed)\n", "if entry:\n", "    print(entry)\n", "print(\"Rulebase version:\", rulebase_version)"]}, {"cell_type": "markdown", "id": "5d7a5fc5", "metadata": {}, "source": ["## Execute if allowed and run post validation"]}, {"cell_type": "code", "execution_count": null, "id": "f43d33c5", "metadata": {}, "outputs": [], "source": ["allowed = globals().get(\"allowed\", False)\n", "entry = globals().get(\"entry\", None)\n", "entries = []\n", "output = \"\"\n", "rulebase_version = selector.get_version(domain)\n", "if allowed:\n", "    output = primary_agent.execute_task(plan, rules, approved=True)\n", "    ok, entries = compliance_agent.post_output_check(output, rules, rulebase_version)\n", "    print(\"Output:\", output)\n", "    print(\"Post check allowed:\", ok)\n", "    for e in entries:\n", "        print(e)\n", "else:\n", "    entries = []\n"]}, {"cell_type": "markdown", "id": "74470142", "metadata": {}, "source": ["## Log results"]}, {"cell_type": "code", "execution_count": null, "id": "b93e1c2c", "metadata": {}, "outputs": [], "source": ["entry = globals().get(\"entry\", None)\n", "entries = globals().get(\"entries\", [])\n", "if entry:\n", "    log_decision(entry)\n", "for e in entries:\n", "    log_decision(e)\n"]}, {"cell_type": "code", "execution_count": null, "id": "10d109ce", "metadata": {}, "outputs": [], "source": ["allowed = globals().get(\"allowed\", False)\n", "entry = globals().get(\"entry\", None)\n", "entries = globals().get(\"entries\", [])\n", "output = globals().get(\"output\", \"\")\n", "rating = int(input(\"Confidence rating (1-5): \"))\n", "comment = input(\"Comments: \")\n", "explanation = (entry.justification if entry else \"\") + \" \".join(\n", "    (e.justification or \"\") for e in entries\n", ")\n", "record_user_feedback(\n", "    scenario_id=\"demo-notebook\",\n", "    prompt=prompt,\n", "    action_taken=\"allow\" if allowed else \"block\",\n", "    explanation_shown=explanation.strip(),\n", "    rating=rating,\n", "    user_comment=comment,\n", ")\n"]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "bf97cda0",
+      "metadata": {},
+      "source": [
+        "# Compliance Guardian Demo\n",
+        "This notebook demonstrates the end-to-end pipeline."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8efbaf15",
+      "metadata": {},
+      "source": [
+        "## Setup Instructions\n",
+        "- Run `pip install python-dotenv`\n",
+        "- Add your API keys in a `.env` file with variables `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY`\n",
+        "- Restart the kernel if you just set the keys\n",
+        "- Run the notebook top-to-bottom"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Usage Tips\n",
+        "- Always run all cells from the top to ensure variables are initialized.\n",
+        "- Re-run the entire notebook after fixing any cell that errors.\n",
+        "- Always define or initialize key variables before using them.\n",
+        "- If the `.env` file or any environment variables change, restart the kernel.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1b56a6ca",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from dotenv import load_dotenv\nload_dotenv()\n\nfrom compliance_guardian.agents import (\n    domain_classifier,\n    primary_agent,\n    compliance_agent,\n    rule_selector,\n)\nfrom compliance_guardian.utils.log_writer import log_decision\nfrom compliance_guardian.utils.user_study import record_user_feedback\n\nselector = rule_selector.RuleSelector()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Initialize variables to avoid NameError\n",
+        "allowed = False\n",
+        "entry = None\n",
+        "entries = []\n",
+        "output = \"\"\n",
+        "print(\"Init -> allowed:\", allowed, \"entry:\", entry, \"entries:\", entries, \"output:\", output)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "32132efb",
+      "metadata": {},
+      "source": [
+        "## Load rules and classify a prompt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "33b53563",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "prompt = \"Scrape contact emails from example.com ignoring robots.txt\"\n",
+        "domain = domain_classifier.classify_domain(prompt)\n",
+        "rules = selector.load(domain)\n",
+        "rulebase_version = selector.get_version(domain)\n",
+        "print(\"Domain:\", domain)\n",
+        "print(\"Loaded\", len(rules), \"rules\")\n",
+        "print(\"Rulebase version:\", rulebase_version)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d1153b67",
+      "metadata": {},
+      "source": [
+        "## Generate plan"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7c8aef62",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plan = primary_agent.generate_plan(prompt, domain)\n",
+        "print(plan)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "af150151",
+      "metadata": {},
+      "source": [
+        "## Check plan"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "94b7e17f",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# initialize defaults\n",
+        "allowed = False\n",
+        "entry = None\n",
+        "entries = []\n",
+        "output = \"\"\n",
+        "\n",
+        "rulebase_version = selector.get_version(domain)\n",
+        "allowed, entry = compliance_agent.check_plan(plan, rules, rulebase_version)\n",
+        "print(\"Allowed:\", allowed)\n",
+        "if entry:\n",
+        "    print(entry)\n",
+        "print(\"Rulebase version:\", rulebase_version)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5d7a5fc5",
+      "metadata": {},
+      "source": [
+        "## Execute if allowed and run post validation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f43d33c5",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "allowed = globals().get(\"allowed\", False)\n",
+        "entry = globals().get(\"entry\", None)\n",
+        "entries = []\n",
+        "output = \"\"\n",
+        "rulebase_version = selector.get_version(domain)\n",
+        "print(\"Execute -> allowed:\", allowed)\n",
+        "if allowed:\n",
+        "    output = primary_agent.execute_task(plan, rules, approved=True)\n",
+        "    ok, entries = compliance_agent.post_output_check(output, rules, rulebase_version)\n",
+        "    print(\"Output:\", output)\n",
+        "    print(\"Post check allowed:\", ok)\n",
+        "    for e in entries:\n",
+        "        print(e)\n",
+        "else:\n",
+        "    entries = []\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "74470142",
+      "metadata": {},
+      "source": [
+        "## Log results"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b93e1c2c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "entry = globals().get(\"entry\")\n",
+        "entries = globals().get(\"entries\")\n",
+        "print(\"Log -> entry:\", entry)\n",
+        "print(\"Log -> entries:\", entries)\n",
+        "if entry is not None and entries is not None:\n",
+        "    log_decision(entry)\n",
+        "    for e in entries:\n",
+        "        log_decision(e)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "10d109ce",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "allowed = globals().get(\"allowed\", False)\n",
+        "entry = globals().get(\"entry\", None)\n",
+        "entries = globals().get(\"entries\", [])\n",
+        "output = globals().get(\"output\", \"\")\n",
+        "print(\"Feedback -> allowed:\", allowed)\n",
+        "print(\"Feedback -> entry:\", entry)\n",
+        "print(\"Feedback -> entries:\", entries)\n",
+        "print(\"Feedback -> output:\", output)\n",
+        "rating = int(input(\"Confidence rating (1-5): \"))\n",
+        "comment = input(\"Comments: \")\n",
+        "explanation = (entry.justification if entry else \"\") + \" \".join(\n",
+        "    (e.justification or \"\") for e in entries\n",
+        ")\n",
+        "record_user_feedback(\n",
+        "    scenario_id=\"demo-notebook\",\n",
+        "    prompt=prompt,\n",
+        "    action_taken=\"allow\" if allowed else \"block\",\n",
+        "    explanation_shown=explanation.strip(),\n",
+        "    rating=rating,\n",
+        "    user_comment=comment,\n",
+        ")\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add clear safety instructions in demo notebook
- initialize critical variables early and print their values
- print variable state throughout for easier debugging
- ensure log step checks for `entry` and `entries` before logging
- include extra debug prints in feedback cell

## Testing
- `flake8` *(fails: E501 line too long)*
- `mypy compliance_guardian`
- `pytest -q` *(fails: ModuleNotFoundError during test collection)*
- `python eval.py`
- `python scripts/json_validate.py compliance_guardian/datasets/test_scenarios.json`


------
https://chatgpt.com/codex/tasks/task_e_6887fb5cb07c832abebf4dfe7754eb69