### PR TITLE
Use Gemini 2.5 flash model

### DIFF
--- a/compliance_guardian/agents/compliance_agent.py
+++ b/compliance_guardian/agents/compliance_agent.py
@@ -59,7 +59,7 @@ def _call_llm(prompt: str, llm: Optional[str]) -> str:
         return content.strip()
     if (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        model = genai.GenerativeModel("gemini-pro")
+        model = genai.GenerativeModel("gemini-2.5-flash")
         res = model.generate_content(prompt)
         return res.text.strip()
     LOGGER.warning("No LLM credentials configured; LLM checks will fail")

--- a/compliance_guardian/agents/domain_classifier.py
+++ b/compliance_guardian/agents/domain_classifier.py
@@ -63,7 +63,7 @@ def _llm_classify(prompt: str) -> str:
             text = raw.strip().lower()
         elif genai and os.getenv("GEMINI_API_KEY"):
             genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-            model = genai.GenerativeModel("gemini-pro")
+            model = genai.GenerativeModel("gemini-2.5-flash")
             res = model.generate_content(system)
             text = res.text.strip().lower()
         else:  # pragma: no cover - only hits when no API keys configured

--- a/compliance_guardian/agents/joint_extractor.py
+++ b/compliance_guardian/agents/joint_extractor.py
@@ -76,7 +76,7 @@ def _llm_extract(prompt: str, llm: Optional[str]) -> Tuple[List[str], List[Rule]
             raw = resp.choices[0].message.content or "{}"
         elif (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
             genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-            model = genai.GenerativeModel("gemini-pro")
+            model = genai.GenerativeModel("gemini-2.5-flash")
             res = model.generate_content(system)
             raw = res.text
         else:

--- a/compliance_guardian/agents/output_validator.py
+++ b/compliance_guardian/agents/output_validator.py
@@ -56,7 +56,7 @@ def _call_llm(prompt: str, llm: Optional[str]) -> str:
         return content.strip()
     if (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        model = genai.GenerativeModel("gemini-pro")
+        model = genai.GenerativeModel("gemini-2.5-flash")
         res = model.generate_content(prompt)
         return res.text.strip()
     LOGGER.warning("No LLM credentials configured; validation falls back")

--- a/compliance_guardian/agents/primary_agent.py
+++ b/compliance_guardian/agents/primary_agent.py
@@ -75,7 +75,7 @@ def _call_llm(messages: Sequence[Dict[str, str]], llm: Optional[str]) -> str:
         return content.strip()
     if (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        model = genai.GenerativeModel("gemini-pro")
+        model = genai.GenerativeModel("gemini-2.5-flash")
         res = model.generate_content("\n".join(m["content"] for m in messages))
         return res.text.strip()
     LOGGER.warning("No LLM credentials configured; falling back to demo plan")

--- a/compliance_guardian/utils/legal_to_json.py
+++ b/compliance_guardian/utils/legal_to_json.py
@@ -40,7 +40,7 @@ def _call_llm(prompt: str) -> str:
         return content.strip()
     if genai and os.getenv("GEMINI_API_KEY"):
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        model = genai.GenerativeModel("gemini-pro")
+        model = genai.GenerativeModel("gemini-2.5-flash")
         res = model.generate_content(prompt)
         return res.text.strip()
     raise RuntimeError("No LLM credentials configured")
@@ -121,7 +121,7 @@ def convert_clause_to_rule(text: str) -> Rule:
         "input_text": text,
         "rule_id": rule.rule_id,
         "domain": domain,
-        "llm_model": os.getenv("OPENAI_MODEL", "gemini-pro"),
+        "llm_model": "gemini-2.5-flash",
     }
     with prov_log.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(provenance) + "\n")


### PR DESCRIPTION
## Summary
- update all Gemini LLM calls to use `gemini-2.5-flash`
- log `gemini-2.5-flash` as the model used during legal clause conversion

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbec2e4cc832a9c3edfb2899bb6c6