### PR TITLE
Handle fenced JSON from LLM responses

### DIFF
--- a/compliance_guardian/agents/joint_extractor.py
+++ b/compliance_guardian/agents/joint_extractor.py
@@ -24,6 +24,7 @@ from compliance_guardian.utils.models import (
     SeverityLevel,
     ComplianceDomain,
 )
+from compliance_guardian.utils.text import _strip_code_fence
 
 try:
     import openai  # type: ignore
@@ -74,11 +75,13 @@ def _llm_extract(prompt: str, llm: Optional[str]) -> Tuple[List[str], List[Rule]
                 temperature=0,
             )
             raw = resp.choices[0].message.content or "{}"
+            raw = _strip_code_fence(raw)
         elif (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
             genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
             model = genai.GenerativeModel("gemini-2.5-flash")
             res = model.generate_content(system)
             raw = res.text or "{}"
+            raw = _strip_code_fence(raw)
         else:
             raise RuntimeError("No LLM credentials available")
         try:

--- a/compliance_guardian/agents/primary_agent.py
+++ b/compliance_guardian/agents/primary_agent.py
@@ -44,6 +44,7 @@ from compliance_guardian.utils.models import (
     RuleType,
     SeverityLevel,
 )
+from compliance_guardian.utils.text import _strip_code_fence
 
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -116,6 +117,7 @@ def generate_plan(
     messages = [{"role": "system", "content": plan_system}]
     try:
         reply = _call_llm(messages, llm)
+        reply = _strip_code_fence(reply)
         parsed = json.loads(reply)
         goal = parsed.get("goal", prompt)
         steps = parsed.get("steps", [])

--- a/compliance_guardian/utils/text.py
+++ b/compliance_guardian/utils/text.py
@@ -1,0 +1,11 @@
+import re
+
+_CODE_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*([\s\S]*?)\s*```\s*$", re.IGNORECASE)
+
+def _strip_code_fence(text: str) -> str:
+    """Return ``text`` without surrounding Markdown code fences."""
+    text = text.strip()
+    match = _CODE_FENCE_RE.match(text)
+    if match:
+        return match.group(1).strip()
+    return text

--- a/tests/test_joint_extractor.py
+++ b/tests/test_joint_extractor.py
@@ -1,4 +1,26 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from compliance_guardian.agents import joint_extractor
+
+
+def _dummy_openai(output: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        OpenAI=lambda: SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **kwargs: SimpleNamespace(
+                        choices=[
+                            SimpleNamespace(
+                                message=SimpleNamespace(content=output)
+                            )
+                        ]
+                    )
+                )
+            )
+        )
+    )
 
 
 def test_joint_extractor_rules():
@@ -6,3 +28,25 @@ def test_joint_extractor_rules():
     domains, rules = joint_extractor.extract(prompt)
     assert "scraping" in domains
     assert rules and rules[0].category == "user"
+
+
+def test_llm_extract_plain_json():
+    output = '{"domains": ["scraping"], "instructions": ["never store emails"]}'
+    dummy = _dummy_openai(output)
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}), patch.object(
+        joint_extractor, "openai", dummy
+    ):
+        domains, rules = joint_extractor._llm_extract("p", llm="openai")
+    assert domains == ["scraping"]
+    assert [r.description for r in rules] == ["never store emails"]
+
+
+def test_llm_extract_code_fence():
+    fenced = "```json\n{\"domains\": [\"scraping\"], \"instructions\": [\"never store emails\"]}\n```"
+    dummy = _dummy_openai(fenced)
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}), patch.object(
+        joint_extractor, "openai", dummy
+    ):
+        domains, rules = joint_extractor._llm_extract("p", llm="openai")
+    assert domains == ["scraping"]
+    assert [r.description for r in rules] == ["never store emails"]

--- a/tests/test_primary_agent.py
+++ b/tests/test_primary_agent.py
@@ -31,6 +31,13 @@ class TestPrimaryAgent:
             assert plan.goal == "g"
             assert plan.sub_actions == ["a", "b"]
 
+    def test_generate_plan_code_fence(self):
+        fenced = "```json\n{\"goal\": \"g\", \"steps\": [\"a\"]}\n```"
+        with patch.object(primary_agent, "_call_llm", return_value=fenced):
+            plan = primary_agent.generate_plan("prompt", ["other"], [])
+            assert plan.goal == "g"
+            assert plan.sub_actions == ["a"]
+
     def test_generate_plan_fallback_on_error(self):
         with patch.object(
             primary_agent, "_call_llm", side_effect=ValueError("fail")


### PR DESCRIPTION
## Summary
- add helper to strip markdown code fences
- sanitize LLM responses in joint extractor and primary agent using the helper
- test parsing of LLM outputs with and without fences

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688feaa37a6c832a8e54fee19be055ee