### PR TITLE
Refactor rule handling for LLM-only compliance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -104,9 +104,17 @@ The resulting file is written to `exports/appendix_export.tex`.
 
 Rule files live in `compliance_guardian/config/rules/DOMAIN.json`. Each rule
 follows the schema defined in `utils/models.py`. Add a new JSON file for a new
-domain and the `RuleSelector` will pick it up automatically. Use
-`python -m compliance_guardian.utils.legal_to_json` to convert legal clauses
-into structured rules.
+domain and the `RuleSelector` will pick it up automatically. The lightweight
+summary files in `config/rules_summary` are generated automatically from the
+full definitions using:
+
+```bash
+python scripts/generate_rules_summary.py
+```
+
+Summary files contain only `rule_id`, a concise `description`, and the
+prescribed `action` so the LLM context stays slim. The full rule files retain
+legal references and concrete suggestions for user feedback.
 
 ## External Datasets and Legal References
 

--- a/compliance_guardian/agents/joint_extractor.py
+++ b/compliance_guardian/agents/joint_extractor.py
@@ -17,7 +17,6 @@ import os
 import re
 from typing import List, Tuple, Optional
 
-
 from compliance_guardian.utils.models import (
     Rule,
     RuleType,
@@ -57,7 +56,6 @@ def _llm_extract(prompt: str, llm: Optional[str]) -> Tuple[List[str], List[Rule]
         Preferred LLM provider (``"openai"`` or ``"gemini"``). ``None`` uses the
         first available provider.
     """
-
 
     system = (
         "Classify the prompt into domains (scraping, finance, medical, other) "
@@ -111,15 +109,12 @@ def _build_user_rule(idx: int, text: str) -> Rule:
         type=RuleType.PROCEDURAL,
         severity=SeverityLevel.HIGH,
         domain=ComplianceDomain.OTHER,
-        pattern=None,
         llm_instruction=text,
         legal_reference=None,
         example_violation=None,
-        index=0,
         category="user",
         action="BLOCK",
-        suggestion="Comply with explicit user instruction.",
-        source="user",
+        suggestion="Follow the user instruction as written.",
     )
 
 

--- a/compliance_guardian/agents/primary_agent.py
+++ b/compliance_guardian/agents/primary_agent.py
@@ -39,10 +39,8 @@ except Exception:  # pragma: no cover - optional dependency
 
 from compliance_guardian.utils.models import (
     PlanSummary,
-    Rule,
+    RuleSummary,
     ComplianceDomain,
-    RuleType,
-    SeverityLevel,
 )
 from compliance_guardian.utils.text import _strip_code_fence
 
@@ -163,7 +161,7 @@ def generate_plan(
 
 def execute_task(
     plan: PlanSummary,
-    rules: List[Rule],
+    rules: List[RuleSummary],
     approved: bool,
     llm: Optional[str] = None,
 ) -> str:
@@ -187,7 +185,7 @@ def execute_task(
         LOGGER.warning("Execution aborted: plan not approved")
         return "Execution aborted: plan not approved"
 
-    rule_lines = [f"({r.rule_id}) {r.llm_instruction or r.description}" for r in rules]
+    rule_lines = [f"({r.rule_id}) {r.description}" for r in rules]
     system_rules = "You must comply with the following rules:\n" + "\n".join(rule_lines)
 
     user_steps = (
@@ -225,22 +223,15 @@ def _demo() -> None:
         "other": "Tell me a fun fact about space",
     }
 
-    dummy_rule = Rule(
+    dummy_rule = RuleSummary(
         rule_id="GEN001",
-        version="1.0.0",
         description="Respond politely and keep answers concise.",
-        type=RuleType.PROCEDURAL,
-        severity=SeverityLevel.LOW,
-        domain=ComplianceDomain.OTHER,
-        pattern=None,
-        llm_instruction=None,
-        legal_reference=None,
-        example_violation=None,
+        action="LOG",
     )
 
     for dom, prmpt in samples.items():
         print(f"\n--- Domain: {dom} ---")
-        plan = generate_plan(prmpt, dom)
+        plan = generate_plan(prmpt, [dom], [])
         # ``model_dump_json`` is used for compatibility with Pydantic v2
         print(plan.model_dump_json(indent=2))
         result = execute_task(plan, [dummy_rule], approved=True)

--- a/compliance_guardian/agents/rule_selector.py
+++ b/compliance_guardian/agents/rule_selector.py
@@ -21,7 +21,7 @@ else:  # pragma: no cover
     Observer = WatchdogObserver
 import typer
 
-from compliance_guardian.utils.models import Rule, RuleSummary, ComplianceDomain
+from compliance_guardian.utils.models import Rule, RuleSummary
 
 
 LOGGER = logging.getLogger(__name__)
@@ -284,12 +284,9 @@ class RuleSelector:
                 versions.append(self.get_version(dom))
             except RuleLoadError:
                 LOGGER.warning("No rules for domain %s", dom)
-        max_index = max((r.index for r in all_rules), default=0)
         if user_rules:
-            for i, r in enumerate(user_rules, start=max_index + 1):
-                r.index = i
+            for r in user_rules:
                 r.category = "user"
-                r.source = "user"
                 all_rules.append(r)
         rulebase_version = "|".join(versions) or "0.0.0"
         return all_rules, rulebase_version

--- a/compliance_guardian/config/rules/finance.json
+++ b/compliance_guardian/config/rules/finance.json
@@ -3,117 +3,83 @@
   "rules": [
     {
       "rule_id": "FIN001",
-      "version": "1.0.0",
-      "description": "Do not expose full account or credit card numbers.",
-      "type": "REGEX",
+      "description": "Never expose full account or credit card numbers.",
+      "type": "LLM",
       "severity": "high",
-      "pattern": "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b",
-      "keywords": [],
       "llm_instruction": null,
       "clause_mapping": {
         "PCI DSS": "Req. 3"
       },
       "legal_reference": "https://www.pcisecuritystandards.org/",
       "example_violation": "Customer card 1234-5678-9012-3456",
-      "index": 1,
       "category": "domain",
       "domain": "finance",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Mask all but the last four digits of card numbers."
     },
     {
       "rule_id": "FIN002",
-      "version": "1.0.0",
-      "description": "Avoid misleading guarantees of investment returns.",
-      "type": "SEMANTIC",
+      "description": "Never promise guaranteed investment returns.",
+      "type": "LLM",
       "severity": "medium",
-      "pattern": null,
-      "keywords": [
-        "guaranteed",
-        "risk-free",
-        "no loss"
-      ],
       "llm_instruction": null,
       "clause_mapping": {
         "SEC": "Rule 10b-5"
       },
       "legal_reference": "https://www.sec.gov/rules/final/33-7825.htm",
       "example_violation": "Our fund offers guaranteed 20% returns",
-      "index": 2,
       "category": "domain",
       "domain": "finance",
       "action": "WARN",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Explain investment risks instead of promising returns."
     },
     {
       "rule_id": "FIN003",
-      "version": "1.0.0",
-      "description": "Require customer consent before sharing financial data with third parties.",
+      "description": "Always obtain explicit customer consent before sharing financial data with third parties.",
       "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [],
       "llm_instruction": "Verify documented consent before any data sharing; otherwise BLOCK the request.",
       "clause_mapping": {
         "GDPR Art. 6": "Lawfulness of processing"
       },
       "legal_reference": "https://gdpr-info.eu/art-6-gdpr/",
       "example_violation": "Sending transaction history to marketing partner",
-      "index": 3,
       "category": "domain",
       "domain": "finance",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Obtain and record customer consent before data sharing."
     },
     {
       "rule_id": "FIN004",
-      "version": "1.0.0",
-      "description": "Detect text suggesting discriminatory lending or denial based on protected attributes.",
-      "type": "SEMANTIC",
+      "description": "Never make lending decisions based on protected attributes.",
+      "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [
-        "redline",
-        "minority",
-        "race",
-        "gender"
-      ],
       "llm_instruction": null,
       "clause_mapping": {
         "Equal Credit Opportunity": "15 U.S.C. \u00a71691"
       },
       "legal_reference": "https://www.consumerfinance.gov/rules-policy/regulations/1002/",
       "example_violation": "We avoid loans in minority neighborhoods",
-      "index": 4,
       "category": "domain",
       "domain": "finance",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Base lending decisions on financial criteria only."
     },
     {
       "rule_id": "FIN005",
-      "version": "1.0.0",
-      "description": "Prevent insider trading tips or non-public information disclosures.",
+      "description": "Do not share insider tips or non-public financial information.",
       "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [],
       "llm_instruction": "If text contains non-public financial details intended for trading advantage, BLOCK and log.",
       "clause_mapping": {
         "US Securities": "15 U.S.C. \u00a778j"
       },
       "legal_reference": "https://www.law.cornell.edu/uscode/text/15/78j",
       "example_violation": "Buy shares before earnings announcement tomorrow",
-      "index": 5,
       "category": "domain",
       "domain": "finance",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Share only information that is already public."
     }
   ]
 }

--- a/compliance_guardian/config/rules/generic.json
+++ b/compliance_guardian/config/rules/generic.json
@@ -3,19 +3,15 @@
   "rules": [
     {
       "rule_id": "GEN001",
-      "index": 1,
-      "description": "Discourage rude or insulting language; respond politely.",
+      "description": "Always respond politely; never use rude or insulting language.",
       "category": "generic",
-      "domain": null,
       "severity": "low",
       "action": "WARN",
-      "type": "semantic",
-      "pattern": null,
+      "type": "LLM",
       "llm_instruction": "Always maintain a polite tone even if the user is disrespectful.",
-      "suggestion": "Maintain respectful communication.",
+      "suggestion": "Use respectful language even if the user is impolite.",
       "legal_reference": null,
-      "example_violation": "You are an idiot",
-      "source": "builtin"
+      "example_violation": "You are an idiot"
     }
   ]
 }

--- a/compliance_guardian/config/rules/medical.json
+++ b/compliance_guardian/config/rules/medical.json
@@ -3,112 +3,83 @@
   "rules": [
     {
       "rule_id": "MED001",
-      "version": "1.0.0",
-      "description": "Mask patient identifiers such as patient IDs or SSNs.",
-      "type": "REGEX",
+      "description": "Never disclose patient identifiers such as patient IDs or Social Security numbers.",
+      "type": "LLM",
       "severity": "high",
-      "pattern": "(?i)(patient\\s*id[:=]\\s*\\d+|\\b\\d{3}-\\d{2}-\\d{4}\\b)",
-      "keywords": [],
       "llm_instruction": null,
       "clause_mapping": {
         "HIPAA": "45 CFR \u00a7164.502"
       },
       "legal_reference": "https://www.hhs.gov/hipaa/for-professionals/privacy/index.html",
       "example_violation": "Patient ID=12345 admitted yesterday",
-      "index": 1,
       "category": "domain",
       "domain": "medical",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Replace identifiers with anonymized codes or remove them."
     },
     {
       "rule_id": "MED002",
-      "version": "1.0.0",
-      "description": "Flag unsubstantiated miracle cure claims.",
-      "type": "SEMANTIC",
+      "description": "Do not claim miracle cures without evidence.",
+      "type": "LLM",
       "severity": "medium",
-      "pattern": null,
-      "keywords": [
-        "miracle cure",
-        "100% effective",
-        "guaranteed healing"
-      ],
       "llm_instruction": null,
       "clause_mapping": {
         "FDA": "21 CFR \u00a7202"
       },
       "legal_reference": "https://www.ecfr.gov/current/title-21/chapter-I/subchapter-B/part-202",
       "example_violation": "This herbal pill is a 100% effective cancer cure",
-      "index": 2,
       "category": "domain",
       "domain": "medical",
       "action": "WARN",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Provide balanced information and cite credible medical sources."
     },
     {
       "rule_id": "MED003",
-      "version": "1.0.0",
-      "description": "Require informed consent before using patient data for research.",
+      "description": "Always obtain informed consent before using patient data for research.",
       "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [],
       "llm_instruction": "Check for documented patient consent before research use; without it issue a BLOCK.",
       "clause_mapping": {
         "Declaration of Helsinki": "Paragraph 25"
       },
       "legal_reference": "https://www.wma.net/what-we-do/medical-ethics/declaration-of-helsinki/",
       "example_violation": "Publishing case study without consent",
-      "index": 3,
       "category": "domain",
       "domain": "medical",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Secure written consent from patients before research use."
     },
     {
       "rule_id": "MED004",
-      "version": "1.0.0",
-      "description": "Detect biased or discriminatory language in clinical notes.",
+      "description": "Never use biased or discriminatory language in clinical notes.",
       "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [],
       "llm_instruction": "Flag and BLOCK notes that stereotype patients based on race, gender, or disability.",
       "clause_mapping": {
         "AMA Ethics": "Opinion 1.1"
       },
       "legal_reference": "https://code-medical-ethics.ama-assn.org/ethics-opinions",
       "example_violation": "The patient is non-compliant because of her ethnicity",
-      "index": 4,
       "category": "domain",
       "domain": "medical",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Describe patients objectively without stereotypes."
     },
     {
       "rule_id": "MED005",
-      "version": "1.0.0",
-      "description": "Avoid copying entire copyrighted medical articles.",
-      "type": "REGEX",
+      "description": "Do not copy entire copyrighted medical articles.",
+      "type": "LLM",
       "severity": "high",
-      "pattern": "(?i)(\u00a9|\\ball rights reserved\\b)\\s.*medical",
-      "keywords": [],
       "llm_instruction": null,
       "clause_mapping": {
         "Copyright": "17 U.S.C."
       },
       "legal_reference": "https://www.copyright.gov/title17/",
       "example_violation": "\u00a9 2024 Medical Journal of Examples all rights reserved",
-      "index": 5,
       "category": "domain",
       "domain": "medical",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Summarize findings in your own words and cite the source."
     }
   ]
 }

--- a/compliance_guardian/config/rules/scraping.json
+++ b/compliance_guardian/config/rules/scraping.json
@@ -3,117 +3,83 @@
   "rules": [
     {
       "rule_id": "SCR001",
-      "version": "1.0.0",
-      "description": "Block collection of email addresses or phone numbers without user consent.",
-      "type": "REGEX",
+      "description": "Do not collect or output email addresses or phone numbers unless explicit user consent is confirmed.",
+      "type": "LLM",
       "severity": "high",
-      "pattern": "(?i)([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})|((?:\\+?\\d{1,3})?\\s?(?:\\(\\d{1,4}\\)|\\d{1,4})?[\\s-]?\\d{3}[\\s-]?\\d{4})",
-      "keywords": [],
       "llm_instruction": null,
       "clause_mapping": {
         "GDPR Art. 6": "Lawfulness of processing"
       },
       "legal_reference": "https://gdpr-info.eu/art-6-gdpr/",
       "example_violation": "Contact us at example@example.com for more info",
-      "index": 1,
       "category": "domain",
       "domain": "scraping",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Ask users to provide contact details via a consent form instead of scraping."
     },
     {
       "rule_id": "SCR002",
-      "version": "1.0.0",
-      "description": "Respect robots.txt and meta tags prohibiting scraping.",
-      "type": "SEMANTIC",
+      "description": "Always respect robots.txt and meta tags that prohibit scraping.",
+      "type": "LLM",
       "severity": "medium",
-      "pattern": null,
-      "keywords": [
-        "robots",
-        "disallow",
-        "noindex",
-        "nofollow"
-      ],
       "llm_instruction": null,
       "clause_mapping": {
         "EU ePrivacy": "Directive 2002/58/EC"
       },
       "legal_reference": "https://eur-lex.europa.eu/eli/dir/2002/58/oj",
       "example_violation": "Robots.txt contains 'Disallow: /private' but scraper ignores it",
-      "index": 2,
       "category": "domain",
       "domain": "scraping",
       "action": "WARN",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Check and honor robots.txt and noindex/nofollow tags before scraping."
     },
     {
       "rule_id": "SCR003",
-      "version": "1.0.0",
-      "description": "Ensure explicit consent before scraping social media profiles.",
+      "description": "Never scrape social media profiles without explicit user consent.",
       "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [],
       "llm_instruction": "If user consent is missing, do not scrape social network data and report a BLOCK.",
       "clause_mapping": {
         "GDPR Art. 7": "Conditions for consent"
       },
       "legal_reference": "https://gdpr-info.eu/art-7-gdpr/",
       "example_violation": "Scraping friends list without consent",
-      "index": 3,
       "category": "domain",
       "domain": "scraping",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Request and document consent from account holders before collecting profile data."
     },
     {
       "rule_id": "SCR004",
-      "version": "1.0.0",
-      "description": "Avoid scraping text marked with copyright notices or 'all rights reserved'.",
-      "type": "REGEX",
+      "description": "Do not scrape content marked with copyright notices or 'all rights reserved'.",
+      "type": "LLM",
       "severity": "high",
-      "pattern": "(?i)(\u00a9|\\ball rights reserved\\b)",
-      "keywords": [],
       "llm_instruction": null,
       "clause_mapping": {
         "EU Copyright": "Directive 2001/29/EC"
       },
       "legal_reference": "https://eur-lex.europa.eu/eli/dir/2001/29/oj",
       "example_violation": "Downloading article with \u00a9 2024 Example Corp",
-      "index": 4,
       "category": "domain",
       "domain": "scraping",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Use content that is explicitly licensed for reuse."
     },
     {
       "rule_id": "SCR005",
-      "version": "1.0.0",
       "description": "Do not circumvent paywalls or authentication mechanisms while scraping.",
-      "type": "SEMANTIC",
+      "type": "LLM",
       "severity": "high",
-      "pattern": null,
-      "keywords": [
-        "paywall",
-        "bypass",
-        "circumvent"
-      ],
       "llm_instruction": null,
       "clause_mapping": {
         "Computer Misuse": "18 U.S.C. \u00a7 1030"
       },
       "legal_reference": "https://www.law.cornell.edu/uscode/text/18/1030",
       "example_violation": "Using scripts to access premium articles without paying",
-      "index": 5,
       "category": "domain",
       "domain": "scraping",
       "action": "BLOCK",
-      "suggestion": "Review for compliance",
-      "source": "builtin"
+      "suggestion": "Access only content available without bypassing security or payment barriers."
     }
   ]
 }

--- a/compliance_guardian/config/rules_summary/finance.json
+++ b/compliance_guardian/config/rules_summary/finance.json
@@ -1,30 +1,27 @@
-{
-  "version": "1.0.0",
-  "rules": [
-    {
-      "rule_id": "FIN001",
-      "description": "Do not expose full account or credit card numbers.",
-      "pattern": "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b"
-    },
-    {
-      "rule_id": "FIN002",
-      "description": "Avoid misleading guarantees of investment returns.",
-      "pattern": null
-    },
-    {
-      "rule_id": "FIN003",
-      "description": "Require customer consent before sharing financial data with third parties.",
-      "pattern": null
-    },
-    {
-      "rule_id": "FIN004",
-      "description": "Detect text suggesting discriminatory lending or denial based on protected attributes.",
-      "pattern": null
-    },
-    {
-      "rule_id": "FIN005",
-      "description": "Prevent insider trading tips or non-public information disclosures.",
-      "pattern": null
-    }
-  ]
-}
+[
+  {
+    "rule_id": "FIN001",
+    "description": "Never expose full account or credit card numbers.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "FIN002",
+    "description": "Never promise guaranteed investment returns.",
+    "action": "WARN"
+  },
+  {
+    "rule_id": "FIN003",
+    "description": "Always obtain explicit customer consent before sharing financial data with third parties.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "FIN004",
+    "description": "Never make lending decisions based on protected attributes.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "FIN005",
+    "description": "Do not share insider tips or non-public financial information.",
+    "action": "BLOCK"
+  }
+]

--- a/compliance_guardian/config/rules_summary/generic.json
+++ b/compliance_guardian/config/rules_summary/generic.json
@@ -1,10 +1,7 @@
-{
-  "version": "1.0.0",
-  "rules": [
-    {
-      "rule_id": "GEN001",
-      "description": "Discourage rude or insulting language; respond politely.",
-      "pattern": null
-    }
-  ]
-}
+[
+  {
+    "rule_id": "GEN001",
+    "description": "Always respond politely; never use rude or insulting language.",
+    "action": "WARN"
+  }
+]

--- a/compliance_guardian/config/rules_summary/medical.json
+++ b/compliance_guardian/config/rules_summary/medical.json
@@ -1,30 +1,27 @@
-{
-  "version": "1.0.0",
-  "rules": [
-    {
-      "rule_id": "MED001",
-      "description": "Mask patient identifiers such as patient IDs or SSNs.",
-      "pattern": "(?i)(patient\\s*id[:=]\\s*\\d+|\\b\\d{3}-\\d{2}-\\d{4}\\b)"
-    },
-    {
-      "rule_id": "MED002",
-      "description": "Flag unsubstantiated miracle cure claims.",
-      "pattern": null
-    },
-    {
-      "rule_id": "MED003",
-      "description": "Require informed consent before using patient data for research.",
-      "pattern": null
-    },
-    {
-      "rule_id": "MED004",
-      "description": "Detect biased or discriminatory language in clinical notes.",
-      "pattern": null
-    },
-    {
-      "rule_id": "MED005",
-      "description": "Avoid copying entire copyrighted medical articles.",
-      "pattern": "(?i)(©|\\ball rights reserved\\b)\\s.*medical"
-    }
-  ]
-}
+[
+  {
+    "rule_id": "MED001",
+    "description": "Never disclose patient identifiers such as patient IDs or Social Security numbers.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "MED002",
+    "description": "Do not claim miracle cures without evidence.",
+    "action": "WARN"
+  },
+  {
+    "rule_id": "MED003",
+    "description": "Always obtain informed consent before using patient data for research.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "MED004",
+    "description": "Never use biased or discriminatory language in clinical notes.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "MED005",
+    "description": "Do not copy entire copyrighted medical articles.",
+    "action": "BLOCK"
+  }
+]

--- a/compliance_guardian/config/rules_summary/scraping.json
+++ b/compliance_guardian/config/rules_summary/scraping.json
@@ -1,30 +1,27 @@
-{
-  "version": "1.0.0",
-  "rules": [
-    {
-      "rule_id": "SCR001",
-      "description": "Block collection of email addresses or phone numbers without user consent.",
-      "pattern": "(?i)([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})|((?:\\+?\\d{1,3})?\\s?(?:\\(\\d{1,4}\\)|\\d{1,4})?[\\s-]?\\d{3}[\\s-]?\\d{4})"
-    },
-    {
-      "rule_id": "SCR002",
-      "description": "Respect robots.txt and meta tags prohibiting scraping.",
-      "pattern": null
-    },
-    {
-      "rule_id": "SCR003",
-      "description": "Ensure explicit consent before scraping social media profiles.",
-      "pattern": null
-    },
-    {
-      "rule_id": "SCR004",
-      "description": "Avoid scraping text marked with copyright notices or 'all rights reserved'.",
-      "pattern": "(?i)(©|\\ball rights reserved\\b)"
-    },
-    {
-      "rule_id": "SCR005",
-      "description": "Do not circumvent paywalls or authentication mechanisms while scraping.",
-      "pattern": null
-    }
-  ]
-}
+[
+  {
+    "rule_id": "SCR001",
+    "description": "Do not collect or output email addresses or phone numbers unless explicit user consent is confirmed.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "SCR002",
+    "description": "Always respect robots.txt and meta tags that prohibit scraping.",
+    "action": "WARN"
+  },
+  {
+    "rule_id": "SCR003",
+    "description": "Never scrape social media profiles without explicit user consent.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "SCR004",
+    "description": "Do not scrape content marked with copyright notices or 'all rights reserved'.",
+    "action": "BLOCK"
+  },
+  {
+    "rule_id": "SCR005",
+    "description": "Do not circumvent paywalls or authentication mechanisms while scraping.",
+    "action": "BLOCK"
+  }
+]

--- a/compliance_guardian/utils/log_writer.py
+++ b/compliance_guardian/utils/log_writer.py
@@ -123,13 +123,10 @@ def log_session_report(entries: List[AuditLogEntry], file_path: str) -> None:
             path = _REPORT_DIR / path
         path.parent.mkdir(parents=True, exist_ok=True)
 
-
         summary = [
             {
                 "rule_id": e.rule_id,
-                "rule_index": e.rule_index,
                 "category": e.category,
-                "source": e.source,
                 "rule_version": e.rule_version,
                 "agent_versions": e.agent_versions,
                 "rulebase_version": e.rulebase_version,
@@ -147,8 +144,8 @@ def log_session_report(entries: List[AuditLogEntry], file_path: str) -> None:
         )
 
         table_lines = [
-            "| rule_id | index | category | source | r_ver | agents | rulebase | clause | action | risk_score | legal_reference |",
-            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            "| rule_id | category | r_ver | agents | rulebase | clause | action | risk_score | legal_reference |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
         for s in summary:
             agents_field = s.get("agent_versions")
@@ -157,11 +154,9 @@ def log_session_report(entries: List[AuditLogEntry], file_path: str) -> None:
             else:
                 agents = ""
             table_lines.append(
-                "| {rule_id} | {index} | {cat} | {src} | {rver} | {agents} | {rbase} | {clause} | {action} | {risk} | {legal} |".format(
+                "| {rule_id} | {cat} | {rver} | {agents} | {rbase} | {clause} | {action} | {risk} | {legal} |".format(
                     rule_id=s["rule_id"],
-                    index=s.get("rule_index") or "",
                     cat=s.get("category") or "",
-                    src=s.get("source") or "",
                     rver=s.get("rule_version") or "",
                     agents=agents,
                     rbase=s.get("rulebase_version") or "",
@@ -172,7 +167,6 @@ def log_session_report(entries: List[AuditLogEntry], file_path: str) -> None:
                 )
             )
         table = "\n".join(table_lines)
-
 
         content = (
             "# ISO/EU Governance Mapping\n\nGenerated: "

--- a/compliance_guardian/utils/models.py
+++ b/compliance_guardian/utils/models.py
@@ -21,8 +21,6 @@ Example:
     ...     type=RuleType.SECURITY,
     ...     severity=SeverityLevel.HIGH,
     ...     domain=ComplianceDomain.GDPR,
-    ...     pattern=r"\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b",
-    ...     keywords=["email"],
     ... )
     >>> rule_dict = rule.to_dict()
 """
@@ -75,8 +73,6 @@ class Rule(BaseModel):
         type: Category of the rule.
         severity: Impact severity if violated.
         domain: Compliance domain to which this rule belongs.
-        pattern: Optional regex pattern used for detection.
-        keywords: Keywords associated with the rule.
         llm_instruction: Instruction for an LLM to comply with this rule.
         clause_mapping: Mapping of clause identifiers to text references.
         legal_reference: Optional legal citation linked to the rule.
@@ -84,25 +80,15 @@ class Rule(BaseModel):
     """
 
     rule_id: str = Field(..., description="Unique identifier for this rule.")
-    version: str = Field(
-        "1.0.0",
-        description=(
-            "Version identifier for this rule allowing full traceability"
-        ),
+    description: str = Field(
+        ..., description="Human-readable rule description."
     )
-    description: str = Field(...,
-                             description="Human-readable rule description.")
     type: RuleType = Field(..., description="Category of the rule.")
-    severity: SeverityLevel = Field(...,
-                                    description="Impact severity if violated.")
+    severity: SeverityLevel = Field(
+        ..., description="Impact severity if violated."
+    )
     domain: ComplianceDomain = Field(
         ..., description="Compliance domain to which this rule belongs."
-    )
-    pattern: Optional[str] = Field(
-        None, description="Regex pattern used to detect rule violations."
-    )
-    keywords: List[str] = Field(
-        default_factory=list, description="Keywords associated with the rule."
     )
     llm_instruction: Optional[str] = Field(
         None, description="Instruction for an LLM to comply with this rule."
@@ -117,9 +103,6 @@ class Rule(BaseModel):
     example_violation: Optional[str] = Field(
         None, description="Example text that violates the rule."
     )
-    index: int = Field(
-        0, description="Unique integer index for fast lookup/logging."
-    )
     category: str = Field(
         "generic", description="Rule category: generic, domain or user."
     )
@@ -129,9 +112,6 @@ class Rule(BaseModel):
     suggestion: Optional[str] = Field(
         None,
         description="Suggested alternative if the rule blocks execution."
-    )
-    source: str = Field(
-        "builtin", description="Origin of the rule: builtin or user."
     )
 
     @classmethod
@@ -181,8 +161,6 @@ class Rule(BaseModel):
                 else:
                     data["action"] = "LOG"
             data.setdefault("category", "generic")
-            data.setdefault("source", "builtin")
-            data.setdefault("index", 0)
             return cls(**data)
         except ValidationError as exc:
             raise ValueError(f"Invalid Rule data: {exc}") from exc
@@ -201,7 +179,7 @@ class RuleSummary(BaseModel):
 
     rule_id: str
     description: Optional[str] = None
-    pattern: Optional[str] = None
+    action: str = "LOG"
 
 
 class AuditLogEntry(BaseModel):
@@ -267,14 +245,8 @@ class AuditLogEntry(BaseModel):
     execution_time: Optional[float] = Field(
         None, description="Time taken to execute in seconds."
     )
-    rule_index: Optional[int] = Field(
-        None, description="Unique index assigned to the rule."
-    )
     category: Optional[str] = Field(
         None, description="Rule category triggering the entry."
-    )
-    source: Optional[str] = Field(
-        None, description="Rule source (builtin or user)."
     )
     legal_reference: Optional[str] = Field(
         None, description="Legal reference associated with the rule."

--- a/compliance_guardian/utils/text.py
+++ b/compliance_guardian/utils/text.py
@@ -2,6 +2,7 @@ import re
 
 _CODE_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*([\s\S]*?)\s*```\s*$", re.IGNORECASE)
 
+
 def _strip_code_fence(text: str) -> str:
     """Return ``text`` without surrounding Markdown code fences."""
     text = text.strip()

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ from compliance_guardian.utils.log_writer import (
     log_decision,
     log_session_report,
 )
-from compliance_guardian.utils.models import AuditLogEntry
+from compliance_guardian.utils.models import AuditLogEntry, Rule, RuleSummary
 
 
 LOGGER = logging.getLogger(__name__)
@@ -37,12 +37,16 @@ app = typer.Typer(help="Run compliance pipeline on prompts")
 # ---------------------------------------------------------------------------
 
 
-def _format_block(entry: AuditLogEntry) -> str:
+def _format_block(rule: Rule) -> str:
     """Build a user facing message for a blocked request."""
 
-    reason = entry.justification or "Request violates policy"
-    reference = f" (Reference: {entry.legal_reference})" if entry.legal_reference else ""
-    return f"Request blocked by rule {entry.rule_id}: {reason}{reference}"
+    reference = (
+        f" (Reference: {rule.legal_reference})" if rule.legal_reference else ""
+    )
+    suggestion = (
+        f" Suggested alternative: {rule.suggestion}" if rule.suggestion else ""
+    )
+    return f"Request blocked by rule {rule.rule_id}: {rule.description}{reference}.{suggestion}"
 
 # ---------------------------------------------------------------------------
 
@@ -123,13 +127,32 @@ def run_pipeline(
     # --- Rule aggregation ---
     selector = selector or rule_selector.RuleSelector()
     rules, rulebase_ver = selector.aggregate(domains, user_rules)
-    LOGGER.info("Loaded %d total rules", len(rules))
-    block_rules = [r for r in rules if r.action == "BLOCK"]
-    warn_rules = [r for r in rules if r.action == "WARN"]
+    rule_lookup = {r.rule_id: r for r in rules}
+
+    summaries: List[RuleSummary] = []
+    for dom in ["generic"] + domains:
+        try:
+            summaries.extend(selector.load_prompt_rules(dom))
+        except rule_selector.RuleLoadError:
+            LOGGER.debug("No summary rules for domain %s", dom)
+    summaries.extend(
+        RuleSummary(rule_id=r.rule_id, description=r.description, action=r.action)
+        for r in user_rules
+    )
+
+    block_rules = [s for s in summaries if s.action == "BLOCK"]
+    warn_rules = [s for s in summaries if s.action == "WARN"]
+
+    if warn_rules:
+        LOGGER.info("The following restrictions will apply:")
+        for s in warn_rules:
+            full = rule_lookup.get(s.rule_id)
+            ref = f" (Reference: {full.legal_reference})" if full and full.legal_reference else ""
+            LOGGER.info("- %s%s", s.description, ref)
 
     # --- Prompt pre-check ---
     allowed_prompt, prompt_entries = compliance_agent.check_prompt(
-        prompt, block_rules, rulebase_ver, llm=llm
+        prompt, block_rules, rule_lookup, rulebase_ver, llm=llm
     )
     for entry in prompt_entries:
         log_decision(entry)
@@ -139,7 +162,8 @@ def run_pipeline(
         LOGGER.warning(
             "Prompt violation %s with action BLOCK", first.rule_id
         )
-        message = _format_block(first)
+        rule = rule_lookup.get(first.rule_id)
+        message = _format_block(rule) if rule else "Request blocked"
         return message, "block", entries
 
     # --- Plan generation ---
@@ -167,7 +191,7 @@ def run_pipeline(
 
     # --- Pre-execution compliance check ---
     allowed, plan_entries = compliance_agent.check_plan(
-        plan, block_rules, rulebase_ver, llm=llm
+        plan, block_rules, rule_lookup, rulebase_ver, llm=llm
     )
     for entry in plan_entries:
         log_decision(entry)
@@ -176,7 +200,8 @@ def run_pipeline(
     if block_entries:
         first = block_entries[0]
         LOGGER.warning("Plan violation %s with action BLOCK", first.rule_id)
-        message = _format_block(first)
+        rule = rule_lookup.get(first.rule_id)
+        message = _format_block(rule) if rule else "Request blocked"
         return message, "block", entries
     LOGGER.info("Plan approved for execution")
 
@@ -192,6 +217,7 @@ def run_pipeline(
     allowed_out, out_entries = compliance_agent.post_output_check(
         output,
         block_rules,
+        rule_lookup,
         rulebase_ver,
         llm=llm,
     )
@@ -202,7 +228,8 @@ def run_pipeline(
     if not allowed_out:
         final_action = "block"
         first = out_entries[0] if out_entries else None
-        message = _format_block(first) if first else "Request blocked"
+        rule = rule_lookup.get(first.rule_id) if first else None
+        message = _format_block(rule) if rule else "Request blocked"
         report_path = "iso_eu_mapping.md"
         log_session_report(entries, report_path)
         LOGGER.info("Pipeline finished with action=%s", final_action)

--- a/scripts/generate_rules_summary.py
+++ b/scripts/generate_rules_summary.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Generate lightweight rule summary files from full rule definitions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+RULE_DIR = Path(__file__).resolve().parents[1] / "compliance_guardian" / "config" / "rules"
+SUMMARY_DIR = RULE_DIR.parent / "rules_summary"
+
+
+def main() -> None:
+    SUMMARY_DIR.mkdir(parents=True, exist_ok=True)
+    for rule_path in RULE_DIR.glob("*.json"):
+        raw = json.loads(rule_path.read_text(encoding="utf-8"))
+        entries = raw.get("rules", []) if isinstance(raw, dict) else raw
+        summaries = [
+            {
+                "rule_id": r["rule_id"],
+                "description": r.get("description"),
+                "action": r.get("action", "LOG"),
+            }
+            for r in entries
+        ]
+        out_path = SUMMARY_DIR / rule_path.name
+        out_path.write_text(json.dumps(summaries, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compliance_agent.py
+++ b/tests/test_compliance_agent.py
@@ -13,7 +13,7 @@ class TestComplianceAgent:
 
     @pytest.fixture()
     def llm_rule(self):
-        return models.Rule.model_construct(
+        rule = models.Rule.model_construct(
             rule_id="R",
             description="no foo",
             type=models.RuleType.LLM,
@@ -22,19 +22,29 @@ class TestComplianceAgent:
             llm_instruction="Does the text mention foo?",
             action="BLOCK",
         )
+        summary = models.RuleSummary(
+            rule_id="R", description="no foo", action="BLOCK"
+        )
+        return rule, summary
 
     @pytest.fixture()
     def semantic_rule(self):
-        return models.Rule.model_construct(
+        rule = models.Rule.model_construct(
             rule_id="S",
             description="be nice",
-            type=models.RuleType.SEMANTIC,
+            type=models.RuleType.LLM,
             severity="high",
             domain="other",
             action="BLOCK",
         )
+        summary = models.RuleSummary(
+            rule_id="S", description="be nice", action="BLOCK"
+        )
+        return rule, summary
 
     def test_check_plan_no_violation(self, llm_rule):
+        rule, summary = llm_rule
+        lookup = {rule.rule_id: rule}
         plan = models.PlanSummary(
             action_plan="bar",
             goal="g",
@@ -46,11 +56,13 @@ class TestComplianceAgent:
             compliance_agent, "_call_llm", return_value="all good"
         ):
             allowed, entries = compliance_agent.check_plan(
-                plan, [llm_rule], "v1"
+                plan, [summary], lookup, "v1"
             )
             assert allowed and not entries
 
     def test_check_plan_llm_block(self, llm_rule):
+        rule, summary = llm_rule
+        lookup = {rule.rule_id: rule}
         plan = models.PlanSummary(
             action_plan="foo",
             goal="g",
@@ -62,12 +74,14 @@ class TestComplianceAgent:
             compliance_agent, "_call_llm", return_value="block"
         ):
             allowed, entries = compliance_agent.check_plan(
-                plan, [llm_rule], "v1"
+                plan, [summary], lookup, "v1"
             )
             assert not allowed
             assert entries and entries[0].action == "BLOCK"
 
     def test_check_plan_semantic(self, semantic_rule):
+        rule, summary = semantic_rule
+        lookup = {rule.rule_id: rule}
         plan = models.PlanSummary(
             action_plan="text",
             goal="g",
@@ -79,12 +93,14 @@ class TestComplianceAgent:
             compliance_agent, "_call_llm", return_value="Yes violation"
         ):
             allowed, entries = compliance_agent.check_plan(
-                plan, [semantic_rule], "v1"
+                plan, [summary], lookup, "v1"
             )
             assert not allowed
             assert entries and "violation" in entries[0].justification.lower()
 
     def test_check_plan_llm_failure(self, semantic_rule):
+        rule, summary = semantic_rule
+        lookup = {rule.rule_id: rule}
         plan = models.PlanSummary(
             action_plan="text",
             goal="g",
@@ -98,17 +114,19 @@ class TestComplianceAgent:
             side_effect=RuntimeError("boom"),
         ):
             allowed, entries = compliance_agent.check_plan(
-                plan, [semantic_rule], "v1"
+                plan, [summary], lookup, "v1"
             )
             assert not allowed
             assert entries and "failed" in entries[0].justification
 
     def test_post_output_check(self, llm_rule):
+        rule, summary = llm_rule
+        lookup = {rule.rule_id: rule}
         with patch.object(
             compliance_agent, "_call_llm", return_value="block"
         ):
             allowed, entries = compliance_agent.post_output_check(
-                "foo bar", [llm_rule], "v1"
+                "foo bar", [summary], lookup, "v1"
             )
             assert not allowed
             assert entries and entries[0].rule_id == "R"

--- a/tests/test_llm_option.py
+++ b/tests/test_llm_option.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import main
 from compliance_guardian.utils import models
 
@@ -21,7 +19,7 @@ def test_run_pipeline_llm_selection(monkeypatch):
             original_prompt=prompt,
         )
 
-    def fake_check_plan(plan, rules, ver, llm=None):
+    def fake_check_plan(plan, rules, lookup, ver, llm=None):
         assert llm == "openai"
         return True, []
 
@@ -29,13 +27,16 @@ def test_run_pipeline_llm_selection(monkeypatch):
         assert llm == "openai"
         return "done"
 
-    def fake_post(output, rules, ver, llm=None):
+    def fake_post(output, rules, lookup, ver, llm=None):
         assert llm == "openai"
         return True, []
 
     class DummySelector:
         def aggregate(self, domains, user_rules):
             return [], "v1"
+
+        def load_prompt_rules(self, domain):
+            return []
 
     monkeypatch.setattr(main.joint_extractor, "extract", fake_extract)
     monkeypatch.setattr(main.primary_agent, "generate_plan", fake_generate_plan)

--- a/tests/test_primary_agent.py
+++ b/tests/test_primary_agent.py
@@ -3,23 +3,14 @@
 from unittest.mock import patch
 
 from compliance_guardian.agents import primary_agent
-from compliance_guardian.utils.models import PlanSummary
-from compliance_guardian.utils import models
+from compliance_guardian.utils.models import PlanSummary, RuleSummary
 
 
 class TestPrimaryAgent:
     """Plan generation and execution with mocked LLM."""
 
     def dummy_rule(self):
-        return models.Rule.model_construct(
-            rule_id="R1",
-            description="desc",
-            type=models.RuleType.REGEX,
-            severity="low",
-            domain="other",
-            pattern="foo",
-            action="LOG",
-        )
+        return RuleSummary(rule_id="R1", description="desc", action="LOG")
 
     def test_generate_plan_success(self):
         with patch.object(

--- a/tests/test_retry_limit.py
+++ b/tests/test_retry_limit.py
@@ -12,6 +12,9 @@ def test_run_pipeline_no_retry(monkeypatch):
         def aggregate(self, domains, user_rules):
             return [], "v1"
 
+        def load_prompt_rules(self, domain):
+            return []
+
     class FakePlan:
         action_plan = "plan"
 
@@ -19,7 +22,7 @@ def test_run_pipeline_no_retry(monkeypatch):
         calls["count"] += 1
         return FakePlan()
 
-    def fake_check_plan(plan, rules, rulebase_ver, llm=None):
+    def fake_check_plan(plan, rules, lookup, rulebase_ver, llm=None):
         entry = AuditLogEntry(
             rule_id="R",
             severity="low",
@@ -52,7 +55,10 @@ def test_run_pipeline_prompt_block(monkeypatch):
         def aggregate(self, domains, user_rules):
             return [], "v1"
 
-    def fake_check_prompt(prompt, rules, ver, llm=None):
+        def load_prompt_rules(self, domain):
+            return []
+
+    def fake_check_prompt(prompt, rules, lookup, ver, llm=None):
         entry = AuditLogEntry(
             rule_id="B", severity="high", action="BLOCK", input_text=prompt,
             justification="blocked", session_id="S", legal_reference="L1"
@@ -71,4 +77,4 @@ def test_run_pipeline_prompt_block(monkeypatch):
     msg, action, _ = main.run_pipeline("bad", "sess")
 
     assert action == "block"
-    assert "B" in msg and "blocked" in msg
+    assert "Request blocked" in msg

--- a/tests/test_risk_scorer.py
+++ b/tests/test_risk_scorer.py
@@ -10,7 +10,7 @@ class TestRiskScorer:
         return models.Rule.model_construct(
             rule_id="R1",
             description="desc",
-            type=models.RuleType.REGEX,
+            type=models.RuleType.LLM,
             severity=severity,
             domain="finance",
         )

--- a/tests/test_rule_selector.py
+++ b/tests/test_rule_selector.py
@@ -23,15 +23,12 @@ class TestRuleSelector:
                 {
                     "rule_id": "T1",
                     "description": "Must say foo",
-                    "type": "REGEX",
+                    "type": "LLM",
                     "severity": "low",
-                    "pattern": "foo",
                     "domain": "generic",
-                    "index": 1,
                     "category": "generic",
                     "action": "LOG",
-                    "suggestion": "Review",
-                    "source": "builtin",
+                    "suggestion": "Use foo politely",
                 }
             ],
         }
@@ -77,12 +74,9 @@ class TestRuleSelector:
         monkeypatch.setattr(rule_selector, "Observer", MagicMock())
         prompt_dir = tmp_rules.parent / "prompts"
         prompt_dir.mkdir()
-        data = {
-            "version": "1.0.0",
-            "rules": [
-                {"rule_id": "T1", "description": "Must say foo", "pattern": "foo"}
-            ],
-        }
+        data = [
+            {"rule_id": "T1", "description": "Must say foo", "action": "LOG"}
+        ]
         (prompt_dir / "generic.json").write_text(
             json.dumps(data), encoding="utf-8"
         )
@@ -93,4 +87,4 @@ class TestRuleSelector:
         assert isinstance(prompts[0], RuleSummary)
         assert prompts[0].description == "Must say foo"
         full = sel.get_rule("generic", "T1")
-        assert full and full.pattern == "foo"
+        assert full and full.description == "Must say foo"


### PR DESCRIPTION
## Summary
- streamline rule schema and summaries for lighter LLM context
- add automatic rules_summary generator
- rework compliance pipeline to use rule summaries and offer clear block messages

## Testing
- `flake8`
- `mypy compliance_guardian`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689387f060f4832aaab8e5e282e93a0e