### PR TITLE
feat: harden LLM prompts with structured templates

### DIFF
--- a/compliance_guardian/agents/output_validator.py
+++ b/compliance_guardian/agents/output_validator.py
@@ -13,7 +13,8 @@ __version__ = "0.2.1"
 
 import logging
 import os
-from typing import Dict, List, Tuple, Optional
+import json
+from typing import Dict, List, Tuple, Optional, Sequence
 
 from compliance_guardian.utils.models import (
     AuditLogEntry,
@@ -41,23 +42,47 @@ logging.basicConfig(level=logging.INFO)
 # ---------------------------------------------------------------------------
 
 
-def _call_llm(prompt: str, llm: Optional[str]) -> str:
+ADJUDICATE_SYSTEM = (
+    "You are a compliance adjudicator. Be conservative and factual. "
+    "Only use evidence present in the TEXT. Do not infer motives or intent beyond the text."
+)
+
+ADJUDICATE_USER_TEMPLATE = """RULE (id={rule_id}, action={action}):
+{rule_desc}
+
+TEXT:
+{text}
+
+Decide strictly on the evidence in TEXT.
+Return JSON only (one line):
+{{"violation": true|false, "confidence": 0.0-1.0, "evidence": "<short quote from TEXT or 'none'>"}}
+"""
+
+
+# ---------------------------------------------------------------------------
+
+def _call_llm(messages: Sequence[Dict[str, str]], llm: Optional[str]) -> str:
     """Invoke the configured LLM and return its textual response."""
 
-    LOGGER.debug("LLM prompt: %s", prompt)
+    LOGGER.debug("LLM messages: %s", messages)
     if (llm in {None, "openai"}) and openai and os.getenv("OPENAI_API_KEY"):
         client = openai.OpenAI()
         resp = client.chat.completions.create(
             model="gpt-3.5-turbo",
-            messages=[{"role": "system", "content": prompt}],
-            temperature=0,
+            messages=messages,  # type: ignore[arg-type]
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=300,
         )
         content = resp.choices[0].message.content or ""
         return content.strip()
     if (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
         model = genai.GenerativeModel("gemini-2.5-flash")
-        res = model.generate_content(prompt)
+        res = model.generate_content(
+            "\n".join(m["content"] for m in messages),
+            generation_config={"temperature": 0.1, "top_p": 0.9},
+        )
         return res.text.strip()
     LOGGER.warning("No LLM credentials configured; validation falls back")
     raise RuntimeError("No LLM credentials configured")
@@ -87,11 +112,23 @@ def _check_rule(
 
     LOGGER.debug("Validating rule %s", rule.rule_id)
     try:
-        prompt = (
-            f"Does the following text violate this rule: {rule.description}? Explain.\n\n{text}"
+        system = ADJUDICATE_SYSTEM
+        user = ADJUDICATE_USER_TEMPLATE.format(
+            rule_id=rule.rule_id,
+            action=rule.action,
+            rule_desc=rule.description or "",
+            text=text,
         )
-        response = _call_llm(prompt, llm)
-        if any(w in response.lower() for w in ("yes", "violation", "block")):
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        response = _call_llm(messages, llm)
+        try:
+            data = json.loads(response)
+        except json.JSONDecodeError:
+            data = {}
+        if data.get("violation"):
             full_rule = rule_lookup.get(rule.rule_id)
             if full_rule:
                 return AuditLogEntry(
@@ -99,7 +136,7 @@ def _check_rule(
                     severity=full_rule.severity,
                     action=full_rule.action,
                     input_text=text,
-                    justification=response,
+                    justification=json.dumps(data),
                     suggested_fix=full_rule.suggestion,
                     clause_id=None,
                     risk_score=_risk_from_severity(full_rule.severity),

--- a/compliance_guardian/utils/i18n.py
+++ b/compliance_guardian/utils/i18n.py
@@ -122,7 +122,9 @@ def translate_explanation(text: str, target_lang: str = "fr") -> str:
                 resp = client.chat.completions.create(
                     model="gpt-3.5-turbo",
                     messages=[{"role": "user", "content": prompt}],
-                    temperature=0,
+                    temperature=0.1,
+                    top_p=0.9,
+                    max_tokens=200,
                 )
                 translated = (
                     resp.choices[0].message.content or ""

--- a/compliance_guardian/utils/legal_to_json.py
+++ b/compliance_guardian/utils/legal_to_json.py
@@ -34,14 +34,19 @@ def _call_llm(prompt: str) -> str:
         resp = client.chat.completions.create(
             model=model,
             messages=[{"role": "system", "content": prompt}],
-            temperature=0,
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=400,
         )
         content = resp.choices[0].message.content or ""
         return content.strip()
     if genai and os.getenv("GEMINI_API_KEY"):
         genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
         model = genai.GenerativeModel("gemini-2.5-flash")
-        res = model.generate_content(prompt)
+        res = model.generate_content(
+            prompt,
+            generation_config={"temperature": 0.1, "top_p": 0.9},
+        )
         return res.text.strip()
     raise RuntimeError("No LLM credentials configured")
 

--- a/tests/test_compliance_agent.py
+++ b/tests/test_compliance_agent.py
@@ -53,7 +53,9 @@ class TestComplianceAgent:
             original_prompt="p",
         )
         with patch.object(
-            compliance_agent, "_call_llm", return_value="all good"
+            compliance_agent,
+            "_call_llm",
+            return_value='{"violation": false, "confidence": 0.1, "evidence": "none"}',
         ):
             allowed, entries = compliance_agent.check_plan(
                 plan, [summary], lookup, "v1"
@@ -71,7 +73,9 @@ class TestComplianceAgent:
             original_prompt="p",
         )
         with patch.object(
-            compliance_agent, "_call_llm", return_value="block"
+            compliance_agent,
+            "_call_llm",
+            return_value='{"violation": true, "confidence": 0.9, "evidence": "bad"}',
         ):
             allowed, entries = compliance_agent.check_plan(
                 plan, [summary], lookup, "v1"
@@ -90,7 +94,9 @@ class TestComplianceAgent:
             original_prompt="p",
         )
         with patch.object(
-            compliance_agent, "_call_llm", return_value="Yes violation"
+            compliance_agent,
+            "_call_llm",
+            return_value='{"violation": true, "confidence": 0.8, "evidence": "mean"}',
         ):
             allowed, entries = compliance_agent.check_plan(
                 plan, [summary], lookup, "v1"
@@ -110,7 +116,9 @@ class TestComplianceAgent:
         summary = models.RuleSummary(rule_id="W", description="no foo", action="WARN")
         lookup = {rule.rule_id: rule}
         with patch.object(
-            compliance_agent, "_call_llm", return_value="violation found"
+            compliance_agent,
+            "_call_llm",
+            return_value='{"violation": true, "confidence": 0.7, "evidence": "foo"}',
         ):
             allowed, entries = compliance_agent.check_prompt(
                 "foo", [summary], lookup, "v1"
@@ -143,7 +151,9 @@ class TestComplianceAgent:
         rule, summary = llm_rule
         lookup = {rule.rule_id: rule}
         with patch.object(
-            compliance_agent, "_call_llm", return_value="block"
+            compliance_agent,
+            "_call_llm",
+            return_value='{"violation": true, "confidence": 0.9, "evidence": "bad"}',
         ):
             allowed, entries = compliance_agent.post_output_check(
                 "foo bar", [summary], lookup, "v1"

--- a/tests/test_joint_extractor.py
+++ b/tests/test_joint_extractor.py
@@ -31,7 +31,10 @@ def test_joint_extractor_rules():
 
 
 def test_llm_extract_plain_json():
-    output = '{"domains": ["scraping"], "instructions": ["never store emails"]}'
+    output = (
+        '{"domains": ["scraping"], "user_rules": '
+        '[{"description_actionable": "never store emails"}]}'
+    )
     dummy = _dummy_openai(output)
     with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}), patch.object(
         joint_extractor, "openai", dummy
@@ -42,7 +45,11 @@ def test_llm_extract_plain_json():
 
 
 def test_llm_extract_code_fence():
-    fenced = "```json\n{\"domains\": [\"scraping\"], \"instructions\": [\"never store emails\"]}\n```"
+    fenced = (
+        """```json
+{"domains": ["scraping"], "user_rules": [{"description_actionable": "never store emails"}]}
+```"""
+    )
     dummy = _dummy_openai(fenced)
     with patch.dict(os.environ, {"OPENAI_API_KEY": "x"}), patch.object(
         joint_extractor, "openai", dummy

--- a/tests/test_output_validator.py
+++ b/tests/test_output_validator.py
@@ -30,7 +30,9 @@ class TestOutputValidator:
         rule, summary = llm_rule
         lookup = {rule.rule_id: rule}
         with patch.object(
-            output_validator, "_call_llm", return_value="Yes violation"
+            output_validator,
+            "_call_llm",
+            return_value='{"violation": true, "confidence": 0.9, "evidence": "bad"}',
         ):
             ok, entries = output_validator.validate_output(
                 "text", [summary], lookup, "v1"
@@ -50,7 +52,9 @@ class TestOutputValidator:
         rule, summary = llm_rule
         lookup = {rule.rule_id: rule}
         with patch.object(
-            output_validator, "_call_llm", return_value="all good"
+            output_validator,
+            "_call_llm",
+            return_value='{"violation": false, "confidence": 0.1, "evidence": "none"}',
         ):
             ok, entries = output_validator.validate_output(
                 "clean", [summary], lookup, "v1"


### PR DESCRIPTION
## Summary
- enforce JSON-only adjudication prompts for rule checks
- add low-temp domain classifier and joint extractor templates
- require planner and executor to adapt steps under WARN constraints

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dcd58e9fc832aa1ba6ab85b745fab