### PR TITLE
feat: make joint_extractor optional with safe fallbacks

### DIFF
--- a/compliance_guardian/utils/log_reader.py
+++ b/compliance_guardian/utils/log_reader.py
@@ -9,21 +9,15 @@ from typing import Dict, List
 from . import log_writer
 
 
-def read_last_entries(limit: int = 100) -> List[Dict]:
-    """Return the last ``limit`` entries from the audit log.
-
-    Parameters
-    ----------
-    limit:
-        Maximum number of entries to return.
-    """
+def read_last_n(n: int = 200) -> List[Dict]:
+    """Return the last ``n`` entries from the audit log."""
 
     path = Path(log_writer._LOG_FILE)  # type: ignore[attr-defined]
     if not path.exists():
         return []
     try:
         with path.open("r", encoding="utf-8") as fh:
-            lines = fh.readlines()[-limit:]
+            lines = fh.readlines()[-n:]
     except Exception:
         return []
     entries: List[Dict] = []

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -2,16 +2,24 @@ from __future__ import annotations
 
 """Streamlit demo interface for the Compliance Guardian pipeline."""
 
-from datetime import datetime
 from pathlib import Path
+import sys
+
+try:  # Ensure local imports work regardless of CWD
+    import compliance_guardian  # noqa: F401
+except Exception:  # pragma: no cover - defensive
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    import compliance_guardian  # noqa: F401
+
+from datetime import datetime
 from typing import List
 
 import pandas as pd
 import streamlit as st
 
-from compliance_guardian.agents import joint_extractor, rule_selector
+from compliance_guardian.agents import rule_selector
 from compliance_guardian.ui.pipeline_api import RunConfig, run_pipeline_events
-from compliance_guardian.utils.log_reader import read_last_entries
+from compliance_guardian.utils.log_reader import read_last_n
 
 
 st.set_page_config(page_title="Compliance Guardian", layout="wide")
@@ -53,7 +61,12 @@ def _render_hits(box, data: dict, show_extra: bool) -> None:
 def _add_user_rule(text: str, rules: List) -> None:
     if not text:
         return
-    rule = joint_extractor._build_user_rule(len(rules) + 1, text)  # type: ignore[attr-defined]
+    try:
+        from compliance_guardian.agents import joint_extractor as _je
+    except Exception:
+        st.warning("Custom rule support unavailable.")
+        return
+    rule = _je._build_user_rule(len(rules) + 1, text)  # type: ignore[attr-defined]
     rules.append(rule)
 
 
@@ -137,7 +150,7 @@ with run_tab:
 
 # Logs tab -----------------------------------------------------------------
 with logs_tab:
-    entries = read_last_entries(200)
+    entries = read_last_n(200)
     if entries:
         df = pd.DataFrame(entries)
         st.dataframe(df, use_container_width=True)


### PR DESCRIPTION
## Summary
- avoid hard imports of `joint_extractor` by guarding path setup in the Streamlit UI and lazily loading the module for custom rules
- add optional domain detection in the pipeline wrapper with a `domain_classifier` fallback and domain-aware rule aggregation
- expose `read_last_n` helper for logs and proxy the joint extractor in the CLI to load only when available
- make rule selector resilient when the optional `watchdog` dependency is missing

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a11d0e0c18832aa62b2ea9acb1603c