### PR TITLE
Raise explicit errors for missing LLM packages or API keys

### DIFF
--- a/compliance_guardian/agents/compliance_agent.py
+++ b/compliance_guardian/agents/compliance_agent.py
@@ -68,25 +68,54 @@ def _call_llm(messages: Sequence[Dict[str, str]], llm: Optional[str]) -> str:
     """Invoke the configured LLM with ``messages`` and return the response."""
 
     LOGGER.debug("LLM messages: %s", messages)
-    if (llm in {None, "openai"}) and openai and os.getenv("OPENAI_API_KEY"):
-        client = openai.OpenAI()
-        resp = client.chat.completions.create(
-            model="gpt-4o",
-            messages=messages,  # type: ignore[arg-type]
-            temperature=0.1,
-            top_p=0.9,
-            max_tokens=300,
-        )
-        content = resp.choices[0].message.content or ""
-        return content.strip()
-    if (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
-        genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        model = genai.GenerativeModel("gemini-2.5-flash")
-        res = model.generate_content(
-            "\n".join(m["content"] for m in messages),
-            generation_config={"temperature": 0.1, "top_p": 0.9},
-        )
-        return res.text.strip()
+    errors: List[str] = []
+    if llm in {None, "openai"}:
+        if openai is None:
+            msg = "OpenAI package not installed"
+            if llm == "openai":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        elif not os.getenv("OPENAI_API_KEY"):
+            msg = "OpenAI API key not configured"
+            if llm == "openai":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        else:
+            client = openai.OpenAI()
+            resp = client.chat.completions.create(
+                model="gpt-4o",
+                messages=messages,  # type: ignore[arg-type]
+                temperature=0.1,
+                top_p=0.9,
+                max_tokens=300,
+            )
+            content = resp.choices[0].message.content or ""
+            return content.strip()
+    if llm in {None, "gemini"}:
+        if genai is None:
+            msg = "Google Generative AI package not installed"
+            if llm == "gemini":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        elif not os.getenv("GEMINI_API_KEY"):
+            msg = "Google Generative AI API key not configured"
+            if llm == "gemini":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        else:
+            genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+            model = genai.GenerativeModel("gemini-2.5-flash")
+            res = model.generate_content(
+                "\n".join(m["content"] for m in messages),
+                generation_config={"temperature": 0.1, "top_p": 0.9},
+            )
+            return res.text.strip()
+    for err in errors:
+        LOGGER.error(err)
     LOGGER.warning("No LLM credentials configured; LLM checks will fail")
     raise RuntimeError("No LLM credentials configured")
 

--- a/compliance_guardian/agents/primary_agent.py
+++ b/compliance_guardian/agents/primary_agent.py
@@ -58,7 +58,7 @@ PLAN_SYSTEM = (
 
 
 def _constraints_block(lines: List[str]) -> str:
-    lines = [l for l in lines if l]
+    lines = [line for line in lines if line]
     return "- " + "\n- ".join(lines) if lines else "(none)"
 
 
@@ -99,25 +99,55 @@ def _coerce_domain(domain: str) -> ComplianceDomain:
 
 def _call_llm(messages: Sequence[Dict[str, str]], llm: Optional[str]) -> str:
     """Internal helper to call either OpenAI or Gemini models."""
-    if (llm in {None, "openai"}) and openai and os.getenv("OPENAI_API_KEY"):
-        client = openai.OpenAI()
-        resp = client.chat.completions.create(
-            model="gpt-4o",
-            messages=messages,  # type: ignore[arg-type]
-            temperature=0.1,
-            top_p=0.9,
-            max_tokens=400,
-        )
-        content = resp.choices[0].message.content or ""
-        return content.strip()
-    if (llm in {None, "gemini"}) and genai and os.getenv("GEMINI_API_KEY"):
-        genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        model = genai.GenerativeModel("gemini-2.5-flash")
-        res = model.generate_content(
-            "\n".join(m["content"] for m in messages),
-            generation_config={"temperature": 0.1, "top_p": 0.9},
-        )
-        return res.text.strip()
+
+    errors: List[str] = []
+    if llm in {None, "openai"}:
+        if openai is None:
+            msg = "OpenAI package not installed"
+            if llm == "openai":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        elif not os.getenv("OPENAI_API_KEY"):
+            msg = "OpenAI API key not configured"
+            if llm == "openai":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        else:
+            client = openai.OpenAI()
+            resp = client.chat.completions.create(
+                model="gpt-4o",
+                messages=messages,  # type: ignore[arg-type]
+                temperature=0.1,
+                top_p=0.9,
+                max_tokens=400,
+            )
+            content = resp.choices[0].message.content or ""
+            return content.strip()
+    if llm in {None, "gemini"}:
+        if genai is None:
+            msg = "Google Generative AI package not installed"
+            if llm == "gemini":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        elif not os.getenv("GEMINI_API_KEY"):
+            msg = "Google Generative AI API key not configured"
+            if llm == "gemini":
+                LOGGER.error(msg)
+                raise RuntimeError(msg)
+            errors.append(msg)
+        else:
+            genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+            model = genai.GenerativeModel("gemini-2.5-flash")
+            res = model.generate_content(
+                "\n".join(m["content"] for m in messages),
+                generation_config={"temperature": 0.1, "top_p": 0.9},
+            )
+            return res.text.strip()
+    for err in errors:
+        LOGGER.error(err)
     LOGGER.warning("No LLM credentials configured; falling back to demo plan")
     raise RuntimeError("No LLM credentials configured")
 


### PR DESCRIPTION
## Summary
- add provider and API key checks to all _call_llm helpers
- surface missing package vs missing key errors in joint_extractor and domain_classifier
- improve log messaging for unavailable LLM providers

## Testing
- `flake8 compliance_guardian/agents/compliance_agent.py compliance_guardian/agents/output_validator.py compliance_guardian/agents/primary_agent.py compliance_guardian/utils/legal_to_json.py compliance_guardian/agents/joint_extractor.py compliance_guardian/agents/domain_classifier.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1fe4f8cd0832ab7935e2ad5eadc74